### PR TITLE
Bump Bumi Mobile packages to version 0.1.1

### DIFF
--- a/Packages/com.bumimobile.audio/package.json
+++ b/Packages/com.bumimobile.audio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.audio",
   "displayName": "Bumi Mobile Audio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Audio playback, pooling, and configuration module for Bumi Mobile projects.",
   "keywords": [
@@ -11,6 +11,6 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0"
+    "com.bumimobile.core": "0.1.1"
   }
 }

--- a/Packages/com.bumimobile.core/package.json
+++ b/Packages/com.bumimobile.core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.core",
   "displayName": "Bumi Mobile Core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Core runtime and initialization utilities for Bumi Mobile modular stack.",
   "keywords": [

--- a/Packages/com.bumimobile.currency/package.json
+++ b/Packages/com.bumimobile.currency/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.currency",
   "displayName": "Bumi Mobile Currency",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Currency definitions, balances, and helpers for Bumi Mobile projects.",
   "keywords": [
@@ -11,6 +11,6 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0"
+    "com.bumimobile.core": "0.1.1"
   }
 }

--- a/Packages/com.bumimobile.defines/package.json
+++ b/Packages/com.bumimobile.defines/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.defines",
   "displayName": "Bumi Mobile Defines",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Define attribute helpers for conditional compilation in Bumi Mobile modules.",
   "keywords": [
@@ -11,6 +11,6 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0"
+    "com.bumimobile.core": "0.1.1"
   }
 }

--- a/Packages/com.bumimobile.haptic/package.json
+++ b/Packages/com.bumimobile.haptic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.haptic",
   "displayName": "Bumi Mobile Haptic",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Haptic feedback wrappers and initialization module for Bumi Mobile projects.",
   "keywords": [
@@ -11,6 +11,6 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0"
+    "com.bumimobile.core": "0.1.1"
   }
 }

--- a/Packages/com.bumimobile.localization/package.json
+++ b/Packages/com.bumimobile.localization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.localization",
   "displayName": "Bumi Mobile Localization",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Localization controller, settings, and editor utilities for Bumi Mobile projects.",
   "keywords": [
@@ -11,7 +11,7 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0",
+    "com.bumimobile.core": "0.1.1",
     "com.unity.textmeshpro": "3.0.9",
     "com.unity.editorcoroutines": "1.0.0",
     "com.unity.nuget.newtonsoft-json": "3.2.1"

--- a/Packages/com.bumimobile.monetization/package.json
+++ b/Packages/com.bumimobile.monetization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.monetization",
   "displayName": "Bumi Mobile Monetization",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Ads, purchasing, and monetization orchestration for Bumi Mobile projects.",
   "keywords": [
@@ -12,7 +12,7 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0",
+    "com.bumimobile.core": "0.1.1",
     "com.unity.textmeshpro": "3.0.9"
   }
 }

--- a/Packages/com.bumimobile.nativeshare/package.json
+++ b/Packages/com.bumimobile.nativeshare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.nativeshare",
   "displayName": "Bumi Mobile Native Share",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "NativeShare integration wrapper for Android and iOS sharing features.",
   "keywords": [
@@ -11,6 +11,6 @@
   ],
   "category": "Integration",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0"
+    "com.bumimobile.core": "0.1.1"
   }
 }

--- a/Packages/com.bumimobile.pool/package.json
+++ b/Packages/com.bumimobile.pool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.pool",
   "displayName": "Bumi Mobile Pool",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Object pooling utilities for Bumi Mobile projects.",
   "keywords": [
@@ -11,6 +11,6 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0"
+    "com.bumimobile.core": "0.1.1"
   }
 }

--- a/Packages/com.bumimobile.pushnotification/package.json
+++ b/Packages/com.bumimobile.pushnotification/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.pushnotification",
   "displayName": "Bumi Mobile Push Notification",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Push notification manager and initializer for Bumi Mobile projects.",
   "keywords": [
@@ -11,7 +11,7 @@
   ],
   "category": "Integration",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0",
+    "com.bumimobile.core": "0.1.1",
     "com.unity.mobile.notifications": "2.4.1"
   }
 }

--- a/Packages/com.bumimobile.save/package.json
+++ b/Packages/com.bumimobile.save/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.save",
   "displayName": "Bumi Mobile Save",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Save system, serializers, and storage helpers for Bumi Mobile projects.",
   "keywords": [
@@ -11,6 +11,6 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0"
+    "com.bumimobile.core": "0.1.1"
   }
 }

--- a/Packages/com.bumimobile.skins/package.json
+++ b/Packages/com.bumimobile.skins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.skins",
   "displayName": "Bumi Mobile Skins",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "Skins system, databases, and editor tooling for Bumi Mobile projects.",
   "keywords": [
@@ -11,6 +11,6 @@
   ],
   "category": "Gameplay",
   "dependencies": {
-    "com.bumimobile.core": "0.1.0"
+    "com.bumimobile.core": "0.1.1"
   }
 }

--- a/Packages/com.bumimobile.ui/package.json
+++ b/Packages/com.bumimobile.ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.ui",
   "displayName": "Bumi Mobile UI",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "unity": "2021.3",
   "description": "UI framework components, overlays, and helpers for Bumi Mobile projects.",
   "keywords": [
@@ -11,7 +11,7 @@
   ],
   "category": "UI",
   "dependencies": {
-  "com.bumimobile.core": "0.1.0",
+  "com.bumimobile.core": "0.1.1",
   "com.unity.textmeshpro": "3.0.9"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -13,7 +13,7 @@
     "com.unity.ugui": "2.0.0",
     "com.unity.textmeshpro": "3.0.9",
     "com.unity.visualscripting": "1.9.5",
-    "com.bumimobile.core": "0.1.0",
+    "com.bumimobile.core": "0.1.1",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -5,7 +5,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0"
+        "com.bumimobile.core": "0.1.1"
       }
     },
     "com.bumimobile.core": {
@@ -22,7 +22,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0"
+        "com.bumimobile.core": "0.1.1"
       }
     },
     "com.bumimobile.defines": {
@@ -30,7 +30,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0"
+        "com.bumimobile.core": "0.1.1"
       }
     },
     "com.bumimobile.haptic": {
@@ -38,7 +38,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0"
+        "com.bumimobile.core": "0.1.1"
       }
     },
     "com.bumimobile.localization": {
@@ -46,7 +46,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0",
+        "com.bumimobile.core": "0.1.1",
         "com.unity.textmeshpro": "3.0.9",
         "com.unity.editorcoroutines": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.2.1"
@@ -57,7 +57,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0",
+        "com.bumimobile.core": "0.1.1",
         "com.unity.textmeshpro": "3.0.9"
       }
     },
@@ -66,7 +66,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0"
+        "com.bumimobile.core": "0.1.1"
       }
     },
     "com.bumimobile.pool": {
@@ -74,7 +74,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0"
+        "com.bumimobile.core": "0.1.1"
       }
     },
     "com.bumimobile.pushnotification": {
@@ -82,7 +82,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0",
+        "com.bumimobile.core": "0.1.1",
         "com.unity.mobile.notifications": "2.4.1"
       }
     },
@@ -91,7 +91,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0"
+        "com.bumimobile.core": "0.1.1"
       }
     },
     "com.bumimobile.skins": {
@@ -99,7 +99,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0"
+        "com.bumimobile.core": "0.1.1"
       }
     },
     "com.bumimobile.ui": {
@@ -107,7 +107,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.bumimobile.core": "0.1.0",
+        "com.bumimobile.core": "0.1.1",
         "com.unity.textmeshpro": "3.0.9"
       }
     },


### PR DESCRIPTION
Updated all Bumi Mobile package versions and their dependencies on com.bumimobile.core from 0.1.0 to 0.1.1. Also updated the manifest and lock files to reference the new core version for consistency across the project.