### PR TITLE
Feature : Update BumiMobile Core - Add Toggle for event system

### DIFF
--- a/Packages/com.bumimobile.core/CHANGELOG.md
+++ b/Packages/com.bumimobile.core/CHANGELOG.md
@@ -19,6 +19,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 ### Changed
 
 - Documentation now consolidated into the package README for quicker onboarding.
+- Disabling `Use Event System` now deactivates the referenced EventSystem and removes auto-wired input modules, preventing duplicate systems from spawning.
+- UI helpers now respect the absence of an event system instead of implicitly creating one at runtime.
 
 ## [0.1.0] - 2025-11-14
 

--- a/Packages/com.bumimobile.core/CHANGELOG.md
+++ b/Packages/com.bumimobile.core/CHANGELOG.md
@@ -10,6 +10,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 - (Add unreleased changes here)
 
+## [0.1.2] - 2025-11-20
+
+### Added
+
+- Optional EventSystem support toggle in `Initializer`, allowing projects to disable automatic input module wiring when using custom setups.
+
+### Changed
+
+- Documentation now consolidated into the package README for quicker onboarding.
+
 ## [0.1.0] - 2025-11-14
 
 ### Added

--- a/Packages/com.bumimobile.core/README.md
+++ b/Packages/com.bumimobile.core/README.md
@@ -1,0 +1,48 @@
+# Bumi Mobile Core
+
+Base infrastructure used by Bumi Mobile projects. This package wires together initialization, module loading, and shared utilities so gameplay assemblies can focus on content.
+
+## Features
+
+- Project bootstrapper (`Initializer`) that persists across scenes and drives the startup pipeline.
+- `ProjectInitSettings` asset orchestrating init modules in a defined order.
+- Module registration system (`InitModule` + `[RegisterModule]`) to plug in optional systems.
+- Utility helpers such as `InitializerContext`, coroutine runner proxies, and scene loading helpers.
+
+## Getting Started
+
+1. **Install the package**
+
+   - Add `com.bumimobile.core` to your Unity project (git reference or scoped registry).
+
+2. **Configure the Initializer prefab**
+
+   - Place the `Initializer` prefab in your startup scene (or create a GameObject and add the `Initializer` component).
+   - Assign your `ProjectInitSettings` asset.
+   - Optionally assign an `EventSystem` and enable `Use Event System` to auto-wire the appropriate input module (Input System UI or Standalone).
+
+3. **Create ProjectInitSettings**
+
+   - Use `Create ▸ BumiMobile ▸ Core ▸ Project Init Settings`.
+   - Add modules via the inspector; drag in assets or reference prefabs as required.
+
+4. **Author Init Modules**
+
+   - Derive from `InitModule` and annotate with `[RegisterModule]` to expose modules in the settings UI.
+   - Override `CreateComponent` / `DestroyComponent` for setup and teardown.
+
+5. **Runtime Scheduling Helpers**
+   - Access `Initializer.GameObject`, `Initializer.Transform`, or `Initializer.RunCoroutine(...)` for shared lifetime management.
+
+## Event System Toggle
+
+The `Initializer` now exposes a `Use Event System` checkbox. When enabled and an `EventSystem` reference is provided, it adds:
+
+- `InputSystemUIInputModule` if the Input System package define `MODULE_INPUT_SYSTEM` is present.
+- Otherwise `StandaloneInputModule` (legacy Input Manager).
+
+Disable the toggle if you manage input modules manually or are using UI frameworks that spin up their own event systems.
+
+## License
+
+Refer to the repository root `LICENSE` file for licensing terms.

--- a/Packages/com.bumimobile.core/README.md
+++ b/Packages/com.bumimobile.core/README.md
@@ -41,7 +41,7 @@ The `Initializer` now exposes a `Use Event System` checkbox. When enabled and an
 - `InputSystemUIInputModule` if the Input System package define `MODULE_INPUT_SYSTEM` is present.
 - Otherwise `StandaloneInputModule` (legacy Input Manager).
 
-Disable the toggle if you manage input modules manually or are using UI frameworks that spin up their own event systems.
+Disable the toggle if you manage input modules manually or are using UI frameworks that spin up their own event systems—the assigned `EventSystem` GameObject will be deactivated and any auto-wired modules will be removed at startup. UI helpers such as `SystemMessage` also check for `EventSystem.current` before registering click handlers, so they won’t spawn a new event system when the toggle is off.
 
 ## License
 

--- a/Packages/com.bumimobile.core/README.md.meta
+++ b/Packages/com.bumimobile.core/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 219f8bd1adf5b3b4aa4ef3a23b2a05b0
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.core/Runtime/Initializer/Initializer.cs
+++ b/Packages/com.bumimobile.core/Runtime/Initializer/Initializer.cs
@@ -13,6 +13,7 @@ namespace BumiMobile
 
         [SerializeField] ProjectInitSettings initSettings;
         [SerializeField] EventSystem eventSystem;
+        [SerializeField] bool useEventSystem = true;
 
         public static GameObject GameObject { get; private set; }
         public static Transform Transform { get; private set; }
@@ -33,11 +34,18 @@ namespace BumiMobile
             Transform = transform;
             InitializerContext.Set(GameObject, Transform);
 
+            if (useEventSystem && eventSystem != null)
+            {
 #if MODULE_INPUT_SYSTEM
-            eventSystem.gameObject.GetOrSetComponent<UnityEngine.InputSystem.UI.InputSystemUIInputModule>();
+                eventSystem.gameObject.GetOrSetComponent<UnityEngine.InputSystem.UI.InputSystemUIInputModule>();
 #else
-            eventSystem.gameObject.GetOrSetComponent<StandaloneInputModule>();
+                eventSystem.gameObject.GetOrSetComponent<StandaloneInputModule>();
 #endif
+            }
+            else if (useEventSystem)
+            {
+                Debug.LogWarning("[Initializer] EventSystem is enabled but no reference was assigned.");
+            }
 
             DontDestroyOnLoad(gameObject);
             initSettings.Init(this);

--- a/Packages/com.bumimobile.core/Runtime/Initializer/Initializer.cs
+++ b/Packages/com.bumimobile.core/Runtime/Initializer/Initializer.cs
@@ -36,6 +36,16 @@ namespace BumiMobile
 
             if (useEventSystem && eventSystem != null)
             {
+                if (!eventSystem.gameObject.activeSelf)
+                {
+                    eventSystem.gameObject.SetActive(true);
+                }
+
+                if (!eventSystem.enabled)
+                {
+                    eventSystem.enabled = true;
+                }
+
 #if MODULE_INPUT_SYSTEM
                 eventSystem.gameObject.GetOrSetComponent<UnityEngine.InputSystem.UI.InputSystemUIInputModule>();
 #else
@@ -45,6 +55,24 @@ namespace BumiMobile
             else if (useEventSystem)
             {
                 Debug.LogWarning("[Initializer] EventSystem is enabled but no reference was assigned.");
+            }
+            else if (!useEventSystem && eventSystem != null)
+            {
+#if MODULE_INPUT_SYSTEM
+                var inputModule = eventSystem.GetComponent<UnityEngine.InputSystem.UI.InputSystemUIInputModule>();
+                if (inputModule != null)
+                {
+                    Destroy(inputModule);
+                }
+#endif
+                var standaloneModule = eventSystem.GetComponent<StandaloneInputModule>();
+                if (standaloneModule != null)
+                {
+                    Destroy(standaloneModule);
+                }
+
+                eventSystem.enabled = false;
+                eventSystem.gameObject.SetActive(false);
             }
 
             DontDestroyOnLoad(gameObject);

--- a/Packages/com.bumimobile.core/Runtime/Initializer/SystemMessage.cs
+++ b/Packages/com.bumimobile.core/Runtime/Initializer/SystemMessage.cs
@@ -177,6 +177,12 @@ namespace BumiMobile
             if (component == null)
                 return;
 
+            if (EventSystem.current == null)
+            {
+                // No active event system: skip wiring pointer callbacks to avoid spawning one automatically
+                return;
+            }
+
             EventTrigger eventTrigger = component.GetComponent<EventTrigger>();
             if (eventTrigger == null)
             {

--- a/Packages/com.bumimobile.core/package.json
+++ b/Packages/com.bumimobile.core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.core",
   "displayName": "Bumi Mobile Core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "unity": "2021.3",
   "description": "Core runtime and initialization utilities for Bumi Mobile modular stack.",
   "keywords": [


### PR DESCRIPTION
This pull request introduces an optional EventSystem support toggle to the core initialization pipeline, allowing projects to control automatic input module wiring and prevent duplicate event systems. Documentation has been consolidated into the package README for easier onboarding, and UI helpers now respect the absence of an event system, improving compatibility with custom setups.

**Event System Integration Improvements**
* Added a `useEventSystem` toggle to the `Initializer` component, enabling or disabling automatic EventSystem activation and input module wiring. When disabled, referenced EventSystem objects are deactivated and auto-wired modules are removed, preventing duplicate systems. [[1]](diffhunk://#diff-b0b02d75a358ee76483220d3e6238aa62f7cf07c9f1f32db9755f541534a009cR16) [[2]](diffhunk://#diff-b0b02d75a358ee76483220d3e6238aa62f7cf07c9f1f32db9755f541534a009cR37-R76)
* UI helpers such as `SystemMessage` now check for an active event system before registering click handlers, avoiding implicit creation of new event systems at runtime.

**Documentation and Usability**
* Consolidated all documentation into the package `README.md`, providing a clearer onboarding guide and usage instructions for the new EventSystem toggle.
* Updated the changelog to reflect the new features and changes in version `0.1.2`.
* Bumped the package version to `0.1.2` in `package.json`.