### PR TITLE
Feature : Add BumiMobile Auth Package

### DIFF
--- a/Packages/com.bumimobile.auth/CHANGELOG.md
+++ b/Packages/com.bumimobile.auth/CHANGELOG.md
@@ -8,6 +8,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 - (Add unreleased changes here)
 
+## [0.1.2] - 2025-11-21
+
+### Added
+
+- Optional `BUMI_AUTH_HAS_FIREBASE` compile flag so the package can compile in stub mode when Firebase SDK is not yet installed.
+- Documented the `BUMI_AUTH_HAS_GPGS` guard for Google Play Games integration.
+
 ## [0.1.1] - 2025-11-20
 
 ### Fixed

--- a/Packages/com.bumimobile.auth/CHANGELOG.md
+++ b/Packages/com.bumimobile.auth/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+- (Add unreleased changes here)
+
+## [0.1.1] - 2025-11-20
+
+### Fixed
+
+- Declared Firebase Auth/App and Google Play Games v2 dependencies in the package manifest to avoid missing reference errors.
+
+## [0.1.0] - 2025-11-20
+
+### Added
+
+- `AuthenticatedInitModule` integrating Auth bootstrap into the core initializer with timeout, skip, and disable flows.
+- `AuthService` wrapping Google Play Games v2 + Firebase Auth sign-in, with anonymous fallback.
+- `CountryService` and `CountryFlagDatabase` for resolving and displaying player country information.
+- Assembly definition and package documentation.

--- a/Packages/com.bumimobile.auth/CHANGELOG.md.meta
+++ b/Packages/com.bumimobile.auth/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b0c46dfb8b848a74ebb7c5bd80c5b9ba
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.auth/README.md
+++ b/Packages/com.bumimobile.auth/README.md
@@ -13,26 +13,31 @@ Authentication foundation for Bumi Mobile projects. This package wraps platform 
 
 1. **Install dependencies**
 
-   - Add Firebase Core/Auth (`com.google.firebase.app`, `com.google.firebase.auth` both `13.4.0`), Google Play Games v2 (`com.google.play.games` `2.1.0`), and [UniTask](https://github.com/Cysharp/UniTask) (`com.cysharp.unitask` `2.5.10`) via the Unity Package Manager or by extending your project `manifest.json`.
+   - Add Firebase Core/Auth (`com.google.firebase.app`, `com.google.firebase.auth`), Google Play Games v2 (`com.google.play.games`), and [UniTask](https://github.com/Cysharp/UniTask) (`com.cysharp.unitask`) via the Unity Package Manager or by extending your project `manifest.json`.
    - Android builds require Google Play Games; iOS builds only consume the Firebase Auth dependency at runtime.
 
-2. **Create the Authenticated Init Module**
+2. **Enable scripting define symbols**
+
+   - Add `BUMI_AUTH_HAS_FIREBASE` (Player Settings ▸ Scripting Define Symbols) after importing the Firebase SDK. Without this flag the runtime falls back to a stub implementation.
+   - Add `BUMI_AUTH_HAS_GPGS` after importing the Google Play Games SDK to enable platform sign-in. Leave it undefined to skip Play Games integration.
+
+3. **Create the Authenticated Init Module**
 
    - Use `Create ▸ BumiMobile ▸ Auth ▸ Authenticated Init Module` to create an asset.
    - (Optional) Assign a `CountryFlagDatabase` for flag lookups.
    - Add the module to your `ProjectInitSettings` asset so it runs before other modules.
 
-3. **Configure skip/disable flags (optional)**
+4. **Configure skip/disable flags (optional)**
 
    - `PlayerPrefs` key `__auth_disabled__` permanently disables auto sign-in when set to `1`.
    - `PlayerPrefs` key `__reset_skip_auth__` skips the next sign-in attempt (cleared automatically).
 
-4. **Using Country Flags**
+5. **Using Country Flags**
 
    - Create a `CountryFlagDatabase` asset and populate ISO codes with sprites and display names.
    - Assign it to the init module so the service can resolve display labels and sprites.
 
-5. **Profile Save Integration (optional)**
+6. **Profile Save Integration (optional)**
    - Define `BUMIMOBILE_PROFILE_SAVE` to enable the helper method `CountryService.CaptureLocationOnceAsync(ProfileSave)` for saving location snapshots.
 
 ## Folder Layout

--- a/Packages/com.bumimobile.auth/README.md
+++ b/Packages/com.bumimobile.auth/README.md
@@ -13,7 +13,7 @@ Authentication foundation for Bumi Mobile projects. This package wraps platform 
 
 1. **Install dependencies**
 
-   - Add Firebase Core/Auth (`com.google.firebase.app`, `com.google.firebase.auth` both `11.8.1`), Google Play Games v2 (`com.google.play.games` `0.11.01`), and [UniTask](https://github.com/Cysharp/UniTask) (`com.cysharp.unitask` `2.5.10`) via the Unity Package Manager or by extending your project `manifest.json`.
+   - Add Firebase Core/Auth (`com.google.firebase.app`, `com.google.firebase.auth` both `13.4.0`), Google Play Games v2 (`com.google.play.games` `2.1.0`), and [UniTask](https://github.com/Cysharp/UniTask) (`com.cysharp.unitask` `2.5.10`) via the Unity Package Manager or by extending your project `manifest.json`.
    - Android builds require Google Play Games; iOS builds only consume the Firebase Auth dependency at runtime.
 
 2. **Create the Authenticated Init Module**

--- a/Packages/com.bumimobile.auth/README.md
+++ b/Packages/com.bumimobile.auth/README.md
@@ -1,0 +1,46 @@
+# Bumi Mobile Auth
+
+Authentication foundation for Bumi Mobile projects. This package wraps platform sign-in (Google Play Games) with Firebase authentication, provides country bootstrap utilities, and exposes an initialization module that plugs into the Core initializer pipeline.
+
+## Features
+
+- `AuthenticatedInitModule` — an init module that signs players in during bootstrap with timeout handling and skip/disable flags persisted via `PlayerPrefs`.
+- `AuthService` — static helper for platform login (Google Play Games v2) linked to Firebase Auth with anonymous fallbacks.
+- `CountryService` — resolves the player country via IP lookup, caches the result, and optionally provides flag sprites via `CountryFlagDatabase` ScriptableObject.
+- `CountryFlagDatabase` — editable asset mapping ISO country codes to flag sprites and localized names.
+
+## Getting Started
+
+1. **Install dependencies**
+
+   - Add Firebase Core/Auth (`com.google.firebase.app`, `com.google.firebase.auth` both `11.8.1`), Google Play Games v2 (`com.google.play.games` `0.11.01`), and [UniTask](https://github.com/Cysharp/UniTask) (`com.cysharp.unitask` `2.5.10`) via the Unity Package Manager or by extending your project `manifest.json`.
+   - Android builds require Google Play Games; iOS builds only consume the Firebase Auth dependency at runtime.
+
+2. **Create the Authenticated Init Module**
+
+   - Use `Create ▸ BumiMobile ▸ Auth ▸ Authenticated Init Module` to create an asset.
+   - (Optional) Assign a `CountryFlagDatabase` for flag lookups.
+   - Add the module to your `ProjectInitSettings` asset so it runs before other modules.
+
+3. **Configure skip/disable flags (optional)**
+
+   - `PlayerPrefs` key `__auth_disabled__` permanently disables auto sign-in when set to `1`.
+   - `PlayerPrefs` key `__reset_skip_auth__` skips the next sign-in attempt (cleared automatically).
+
+4. **Using Country Flags**
+
+   - Create a `CountryFlagDatabase` asset and populate ISO codes with sprites and display names.
+   - Assign it to the init module so the service can resolve display labels and sprites.
+
+5. **Profile Save Integration (optional)**
+   - Define `BUMIMOBILE_PROFILE_SAVE` to enable the helper method `CountryService.CaptureLocationOnceAsync(ProfileSave)` for saving location snapshots.
+
+## Folder Layout
+
+- `Runtime/` — runtime scripts and assembly definition.
+- `CHANGELOG.md` — version history following Keep a Changelog.
+- `package.json` — Unity package manifest.
+
+## License
+
+See the repository root `LICENSE` file for terms.

--- a/Packages/com.bumimobile.auth/README.md.meta
+++ b/Packages/com.bumimobile.auth/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9d0c857efbd9cd54e988e802f471c5ca
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.auth/Runtime.meta
+++ b/Packages/com.bumimobile.auth/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d57ae62f46244d7418dd1307d6a83bf0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.auth/Runtime/AuthService.cs
+++ b/Packages/com.bumimobile.auth/Runtime/AuthService.cs
@@ -1,0 +1,326 @@
+using System;
+using UnityEngine;
+using Cysharp.Threading.Tasks;
+
+using Firebase;
+using Firebase.Auth;
+
+#if UNITY_ANDROID
+using GooglePlayGames;
+using GooglePlayGames.BasicApi;
+#endif
+
+namespace BumiMobile
+{
+    public static class AuthService
+    {
+        // ---- Identity / State ----
+        public static string PlayerId { get; private set; } = string.Empty; // PGS id
+        public static FirebaseUser User { get; private set; }
+        public static bool IsFirebaseAnonymous => User != null && User.IsAnonymous;
+        // UI indicator: treat any Firebase user (including anonymous) as "logged in"
+        public static bool IsAuthenticated => User != null;
+        // Strong sign-in (linked account): non-anonymous only
+        public static bool IsSignedIn => User != null && !User.IsAnonymous;
+
+        static bool _busy;
+        static bool _pgsActivated;
+        public static string LastAuthFailureReason { get; private set; } = string.Empty;
+
+        // Events
+        public static event Action<bool> OnPgsAuthFinished;            // kept for compatibility (Android)
+        public static event Action<FirebaseUser> OnFirebaseAuthChanged; // user (can be null)
+
+        // ====================================================================
+        // PUBLIC API
+        // ====================================================================
+
+        /// <summary>
+        /// Try platform sign-in (PGS on Android), then Firebase.
+        /// Fallback to Firebase Anonymous on failure.
+        /// Returns true when non-anonymous Firebase user is signed in.
+        /// </summary>
+        public static async UniTask<bool> SignInAsync(bool forceRefreshToken = true)
+        {
+            if (_busy) { Debug.LogWarning("[Auth] Sign-in already running"); return false; }
+            _busy = true;
+            try
+            {
+                return await InternalSignInAsync(forceRefreshToken, interactive: true, manual: false);
+            }
+            finally { _busy = false; }
+        }
+
+        /// <summary>
+        /// Manual variant for a "Sign in" button.
+        /// </summary>
+        public static async UniTask<bool> ManualSignInAsync()
+        {
+            if (_busy) return false;
+            _busy = true;
+            try
+            {
+                return await InternalSignInAsync(forceRefreshToken: true, interactive: true, manual: true);
+            }
+            finally { _busy = false; }
+        }
+
+        public static async UniTask<bool> SignOutAsync()
+        {
+            try
+            {
+                var dep = await FirebaseApp.CheckAndFixDependenciesAsync();
+                if (dep == DependencyStatus.Available)
+                {
+                    var auth = FirebaseAuth.DefaultInstance;
+                    auth?.SignOut();
+                }
+
+                // PGS v2: no explicit sign-out API (Android)
+
+                PlayerId = string.Empty;
+                User = null;
+                OnFirebaseAuthChanged?.Invoke(null);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[Auth] SignOut failed: " + e.Message);
+                return false;
+            }
+        }
+
+        // ====================================================================
+        // CORE FLOW
+        // ====================================================================
+
+        static async UniTask<bool> InternalSignInAsync(bool forceRefreshToken, bool interactive, bool manual)
+        {
+#if UNITY_ANDROID
+            EnsurePgsActivated();
+            bool platformOk = await PgsAuthenticateAsync(interactive, manual);
+            if (!platformOk)
+            {
+                Debug.LogWarning("[Auth] PGS auth failed – fallback to anonymous Firebase.");
+                await EnsureFirebaseAnonIfPossibleAsync();
+                return false;
+            }
+
+            PlayerId = PlayGamesPlatform.Instance?.localUser?.id ?? string.Empty;
+            if (string.IsNullOrEmpty(PlayerId))
+                Debug.LogWarning("[Auth] PGS returned empty player id.");
+
+            bool firebaseOk = await TryLoginOrLinkFirebaseWithPgsAsync(forceRefreshToken);
+            if (!firebaseOk)
+            {
+                Debug.LogWarning("[Auth] Firebase sign-in/link with PGS failed – fallback anonymous.");
+                await EnsureFirebaseAnonIfPossibleAsync();
+                return false;
+            }
+            return true;
+
+#else
+            // On iOS and other platforms, use Firebase Anonymous only
+            Debug.Log("[Auth] Using Firebase Anonymous (no platform sign-in on iOS).");
+            await EnsureFirebaseAnonIfPossibleAsync();
+            return false;
+#endif
+        }
+
+        // ====================================================================
+        // LABEL
+        // ====================================================================
+
+        public static string GetUserLabel()
+        {
+            // Prefer Firebase displayName/email; fallback to platform identity
+            var name = User?.DisplayName;
+            var mail = User?.Email;
+            if (!string.IsNullOrEmpty(name)) return name;
+            if (!string.IsNullOrEmpty(mail)) return mail;
+
+#if UNITY_ANDROID
+            var pgsName = PlayGamesPlatform.Instance?.localUser?.userName;
+            if (!string.IsNullOrEmpty(pgsName)) return pgsName;
+#endif
+
+            if (!string.IsNullOrEmpty(PlayerId)) return $"Player {PlayerId}";
+            return string.Empty;
+        }
+
+        // ====================================================================
+        // ANDROID (PGS)
+        // ====================================================================
+
+#if UNITY_ANDROID
+        static void EnsurePgsActivated()
+        {
+            if (_pgsActivated) return;
+            PlayGamesPlatform.DebugLogEnabled = true;
+            PlayGamesPlatform.Activate();
+            _pgsActivated = true;
+        }
+
+        static UniTask<bool> PgsAuthenticateAsync(bool interactive, bool manual = false)
+        {
+            var tcs = new UniTaskCompletionSource<bool>();
+
+            void SetResult(SignInStatus s)
+            {
+                if (s != SignInStatus.Success)
+                    LastAuthFailureReason = "PGS SignInStatus=" + s;
+                tcs.TrySetResult(s == SignInStatus.Success);
+                OnPgsAuthFinished?.Invoke(s == SignInStatus.Success);
+            }
+
+            try
+            {
+                if (PlayGamesPlatform.Instance == null)
+                {
+                    Debug.LogWarning("[Auth] PGS Instance null before authenticate.");
+                    tcs.TrySetResult(false);
+                }
+                else
+                {
+                    if (manual)
+                        PlayGamesPlatform.Instance.ManuallyAuthenticate(SetResult);
+                    else
+                        PlayGamesPlatform.Instance.Authenticate(SetResult);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[Auth] PGS authenticate threw: " + e.Message);
+                tcs.TrySetResult(false);
+            }
+
+            return tcs.Task;
+        }
+
+        static UniTask<string> RequestPgsServerAuthCodeAsync(bool forceRefreshToken)
+        {
+            var tcs = new UniTaskCompletionSource<string>();
+            try
+            {
+                if (PlayGamesPlatform.Instance == null)
+                {
+                    tcs.TrySetException(new Exception("PGS Instance null"));
+                }
+                else
+                {
+                    PlayGamesPlatform.Instance.RequestServerSideAccess(
+                        forceRefreshToken,
+                        code =>
+                        {
+                            if (string.IsNullOrEmpty(code))
+                                tcs.TrySetException(new Exception("Empty auth code"));
+                            else
+                                tcs.TrySetResult(code);
+                        });
+                }
+            }
+            catch (Exception e) { tcs.TrySetException(e); }
+            return tcs.Task;
+        }
+
+        /// <summary>Firebase with PGS credential (Android)</summary>
+        static async UniTask<bool> TryLoginOrLinkFirebaseWithPgsAsync(bool forceRefreshToken)
+        {
+            try
+            {
+                var dep = await FirebaseApp.CheckAndFixDependenciesAsync();
+                if (dep != DependencyStatus.Available)
+                {
+                    Debug.LogWarning($"[Auth] Firebase deps: {dep}");
+                    return false;
+                }
+
+                var auth = FirebaseAuth.DefaultInstance;
+                if (auth == null) { Debug.LogWarning("[Auth] FirebaseAuth.DefaultInstance null."); return false; }
+
+                // Get server auth code (with one retry forcing refresh)
+                string authCode = null;
+                Exception lastCodeErr = null;
+                for (int attempt = 0; attempt < 2 && string.IsNullOrEmpty(authCode); attempt++)
+                {
+                    bool force = attempt == 1 ? true : forceRefreshToken;
+                    try
+                    {
+                        authCode = await RequestPgsServerAuthCodeAsync(force);
+                    }
+                    catch (Exception e) { lastCodeErr = e; }
+                }
+                if (string.IsNullOrEmpty(authCode))
+                {
+                    LastAuthFailureReason = "Empty PGS auth code: " + (lastCodeErr?.Message ?? "Unknown");
+                    return false;
+                }
+
+                var cred = PlayGamesAuthProvider.GetCredential(authCode);
+                if (cred == null) { LastAuthFailureReason = "Null PGS credential"; return false; }
+
+                if (auth.CurrentUser == null)
+                {
+                    User = await auth.SignInWithCredentialAsync(cred);
+                    OnFirebaseAuthChanged?.Invoke(User);
+                    return User != null;
+                }
+
+                if (auth.CurrentUser.IsAnonymous)
+                {
+                    await auth.CurrentUser.LinkWithCredentialAsync(cred); // upgrade anon
+                    await auth.CurrentUser.ReloadAsync();
+                    User = auth.CurrentUser;
+                    OnFirebaseAuthChanged?.Invoke(User);
+                    return true;
+                }
+
+                User = await auth.SignInWithCredentialAsync(cred); // re-sign
+                OnFirebaseAuthChanged?.Invoke(User);
+                return User != null;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[Auth] Firebase PGS step failed: " + e.Message);
+                LastAuthFailureReason = e.Message;
+                return false;
+            }
+        }
+#endif // UNITY_ANDROID
+
+        // ====================================================================
+        // Firebase Anonymous Fallback (Common)
+        // ====================================================================
+
+        static async UniTask<bool> EnsureFirebaseAnonIfPossibleAsync()
+        {
+            try
+            {
+                var dep = await FirebaseApp.CheckAndFixDependenciesAsync();
+                if (dep != DependencyStatus.Available)
+                {
+                    Debug.LogWarning($"[Auth] Firebase deps not available for anonymous: {dep}");
+                    return false;
+                }
+
+                var auth = FirebaseAuth.DefaultInstance;
+                if (auth.CurrentUser != null)
+                {
+                    User = auth.CurrentUser;
+                    return true;
+                }
+
+                var res = await auth.SignInAnonymouslyAsync();
+                User = res?.User;
+                Debug.Log($"[Auth] Firebase Anonymous OK: {User?.UserId}");
+                OnFirebaseAuthChanged?.Invoke(User);
+                return User != null;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[Auth] Anonymous sign-in failed: " + e.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/Packages/com.bumimobile.auth/Runtime/AuthService.cs
+++ b/Packages/com.bumimobile.auth/Runtime/AuthService.cs
@@ -5,7 +5,7 @@ using Cysharp.Threading.Tasks;
 using Firebase;
 using Firebase.Auth;
 
-#if UNITY_ANDROID
+#if UNITY_ANDROID && BUMI_AUTH_HAS_GPGS
 using GooglePlayGames;
 using GooglePlayGames.BasicApi;
 #endif
@@ -96,7 +96,7 @@ namespace BumiMobile
 
         static async UniTask<bool> InternalSignInAsync(bool forceRefreshToken, bool interactive, bool manual)
         {
-#if UNITY_ANDROID
+#if UNITY_ANDROID && BUMI_AUTH_HAS_GPGS
             EnsurePgsActivated();
             bool platformOk = await PgsAuthenticateAsync(interactive, manual);
             if (!platformOk)
@@ -120,8 +120,11 @@ namespace BumiMobile
             return true;
 
 #else
-            // On iOS and other platforms, use Firebase Anonymous only
-            Debug.Log("[Auth] Using Firebase Anonymous (no platform sign-in on iOS).");
+#if UNITY_ANDROID
+            Debug.Log("[Auth] Google Play Games SDK not available; using Firebase Anonymous fallback.");
+#else
+            Debug.Log("[Auth] Using Firebase Anonymous (no platform sign-in on this platform).");
+#endif
             await EnsureFirebaseAnonIfPossibleAsync();
             return false;
 #endif
@@ -139,7 +142,7 @@ namespace BumiMobile
             if (!string.IsNullOrEmpty(name)) return name;
             if (!string.IsNullOrEmpty(mail)) return mail;
 
-#if UNITY_ANDROID
+#if UNITY_ANDROID && BUMI_AUTH_HAS_GPGS
             var pgsName = PlayGamesPlatform.Instance?.localUser?.userName;
             if (!string.IsNullOrEmpty(pgsName)) return pgsName;
 #endif
@@ -152,7 +155,7 @@ namespace BumiMobile
         // ANDROID (PGS)
         // ====================================================================
 
-#if UNITY_ANDROID
+#if UNITY_ANDROID && BUMI_AUTH_HAS_GPGS
         static void EnsurePgsActivated()
         {
             if (_pgsActivated) return;
@@ -286,7 +289,7 @@ namespace BumiMobile
                 return false;
             }
         }
-#endif // UNITY_ANDROID
+#endif // UNITY_ANDROID && BUMI_AUTH_HAS_GPGS
 
         // ====================================================================
         // Firebase Anonymous Fallback (Common)

--- a/Packages/com.bumimobile.auth/Runtime/AuthService.cs
+++ b/Packages/com.bumimobile.auth/Runtime/AuthService.cs
@@ -2,14 +2,19 @@ using System;
 using UnityEngine;
 using Cysharp.Threading.Tasks;
 
+#if BUMI_AUTH_HAS_FIREBASE
 using Firebase;
 using Firebase.Auth;
+#else
+using FirebaseUser = System.Object;
+#endif
 
-#if UNITY_ANDROID && BUMI_AUTH_HAS_GPGS
+#if UNITY_ANDROID && BUMI_AUTH_HAS_GPGS && BUMI_AUTH_HAS_FIREBASE
 using GooglePlayGames;
 using GooglePlayGames.BasicApi;
 #endif
 
+#if BUMI_AUTH_HAS_FIREBASE
 namespace BumiMobile
 {
     public static class AuthService
@@ -327,3 +332,46 @@ namespace BumiMobile
         }
     }
 }
+#else
+namespace BumiMobile
+{
+    public static class AuthService
+    {
+        public static string PlayerId { get; private set; } = string.Empty;
+        public static FirebaseUser User => null;
+        public static bool IsFirebaseAnonymous => true;
+        public static bool IsAuthenticated => false;
+        public static bool IsSignedIn => false;
+        public static string LastAuthFailureReason { get; private set; } = "Firebase SDK missing. Define BUMI_AUTH_HAS_FIREBASE after importing Firebase packages.";
+
+        public static event Action<bool> OnPgsAuthFinished;
+        public static event Action<FirebaseUser> OnFirebaseAuthChanged;
+
+        public static UniTask<bool> SignInAsync(bool forceRefreshToken = true)
+        {
+            LogStubWarning();
+            return UniTask.FromResult(false);
+        }
+
+        public static UniTask<bool> ManualSignInAsync()
+        {
+            LogStubWarning();
+            return UniTask.FromResult(false);
+        }
+
+        public static UniTask<bool> SignOutAsync()
+        {
+            LogStubWarning();
+            return UniTask.FromResult(false);
+        }
+
+        public static string GetUserLabel() => string.Empty;
+
+        static void LogStubWarning()
+        {
+            LastAuthFailureReason = "Firebase SDK missing. Define BUMI_AUTH_HAS_FIREBASE after importing Firebase packages.";
+            Debug.LogWarning("[Auth] Firebase SDK not detected. AuthService is running in stub mode.");
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.auth/Runtime/AuthService.cs.meta
+++ b/Packages/com.bumimobile.auth/Runtime/AuthService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 48767f8238ba8d744be75e4f5a7ab6a2

--- a/Packages/com.bumimobile.auth/Runtime/AuthenticatedInitModule.cs
+++ b/Packages/com.bumimobile.auth/Runtime/AuthenticatedInitModule.cs
@@ -1,0 +1,118 @@
+// Scripts/Auth/AuthenticatedInitModule.cs
+// ------------------------------------------------------------
+// AuthenticatedInitModule
+// - ORDER = 0 (paling awal)
+// - Async coroutine dengan timeout
+// - Country bootstrap simplified (only flag database sprite assignment). Locale removed.
+// - Jalankan AuthService.SignInAsync()
+// - Expose status IsAuthenticated / PlayerName / PlayerId
+// ------------------------------------------------------------
+
+using System;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace BumiMobile
+{
+    [CreateAssetMenu(menuName = "BumiMobile/Auth/Authenticated Init Module", fileName = "AuthenticatedInitModule")]
+    [RegisterModule("Authenticated", core: true, order: 0)]
+    public class AuthenticatedInitModule : InitModule
+    {
+        private const string SkipAuthKey = "__reset_skip_auth__";
+        private const string AuthDisabledKey = "__auth_disabled__";
+
+        [Header("Timeout (seconds)")]
+        [SerializeField] private float timeoutSeconds = 25f;
+        [SerializeField] private CountryFlagDatabase countryFlags;
+
+        public static bool IsAuthenticated { get; private set; }
+
+        public override string ModuleName => "Authenticated";
+
+        public override void CreateComponent()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            InitializeAsync().Forget();
+        }
+
+        private async UniTaskVoid InitializeAsync()
+        {
+            Debug.Log("[Auth] Init start");
+
+            var countryInitTask = InitializeCountryAsync();
+
+            if (PlayerPrefs.GetInt(AuthDisabledKey, 0) == 1)
+            {
+                Debug.Log("[Auth] Auto sign-in disabled by user (persistent).");
+                IsAuthenticated = false;
+                await countryInitTask;
+                return;
+            }
+
+            if (PlayerPrefs.GetInt(SkipAuthKey, 0) == 1)
+            {
+                PlayerPrefs.DeleteKey(SkipAuthKey);
+                PlayerPrefs.Save();
+                Debug.Log("[Auth] Skipping authentication after sign-out");
+                IsAuthenticated = false;
+                await countryInitTask;
+                return;
+            }
+
+            bool timedOut = false;
+            bool signInResult = false;
+
+            try
+            {
+                var signInTask = AuthService.SignInAsync(true);
+                var timeoutTask = UniTask.Delay(TimeSpan.FromSeconds(Mathf.Max(1f, timeoutSeconds)));
+                var winner = await UniTask.WhenAny(signInTask, timeoutTask);
+
+                if (winner == 0)
+                {
+                    signInResult = await signInTask;
+                }
+                else
+                {
+                    timedOut = true;
+                }
+            }
+            catch (Exception e)
+            {
+                timedOut = false;
+                signInResult = false;
+                Debug.LogWarning("[Auth] Sign-in encountered an exception: " + e.Message);
+            }
+
+            await countryInitTask;
+
+            if (timedOut)
+            {
+                Debug.LogWarning("[Auth] Init timeout — continuing without authenticated session.");
+                IsAuthenticated = false;
+                return;
+            }
+
+            IsAuthenticated = signInResult;
+            Debug.Log($"[Auth] Init done | ok={IsAuthenticated} | id={AuthService.PlayerId} | country={CountryService.CountryISO}");
+        }
+
+        private UniTask InitializeCountryAsync()
+        {
+            var task = CountryService.InitializeAsync();
+            return task.ContinueWith(() =>
+            {
+                if (countryFlags != null)
+                {
+                    CountryService.SetFlagDatabase(countryFlags);
+                }
+
+                Debug.Log($"[Auth] Country resolved ISO={CountryService.CountryISO} Name={CountryService.CountryName}");
+            });
+        }
+    }
+}

--- a/Packages/com.bumimobile.auth/Runtime/AuthenticatedInitModule.cs.meta
+++ b/Packages/com.bumimobile.auth/Runtime/AuthenticatedInitModule.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0af31c8827dbcfd4390fe66ded267539

--- a/Packages/com.bumimobile.auth/Runtime/BumiMobile.Auth.asmdef
+++ b/Packages/com.bumimobile.auth/Runtime/BumiMobile.Auth.asmdef
@@ -1,0 +1,15 @@
+{
+  "name": "BumiMobile.Auth",
+  "references": [
+    "BumiMobile.Core",
+    "UniTask"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "noEngineReferences": false
+}

--- a/Packages/com.bumimobile.auth/Runtime/BumiMobile.Auth.asmdef
+++ b/Packages/com.bumimobile.auth/Runtime/BumiMobile.Auth.asmdef
@@ -11,7 +11,8 @@
   "precompiledReferences": [],
   "autoReferenced": true,
   "defineConstraints": [
-    "BUMI_AUTH_HAS_GPGS"
+    "BUMI_AUTH_HAS_GPGS",
+    "BUMI_AUTH_HAS_FIREBASE"
   ],
   "noEngineReferences": false
 }

--- a/Packages/com.bumimobile.auth/Runtime/BumiMobile.Auth.asmdef
+++ b/Packages/com.bumimobile.auth/Runtime/BumiMobile.Auth.asmdef
@@ -10,6 +10,8 @@
   "overrideReferences": false,
   "precompiledReferences": [],
   "autoReferenced": true,
-  "defineConstraints": [],
+  "defineConstraints": [
+    "BUMI_AUTH_HAS_GPGS"
+  ],
   "noEngineReferences": false
 }

--- a/Packages/com.bumimobile.auth/Runtime/BumiMobile.Auth.asmdef.meta
+++ b/Packages/com.bumimobile.auth/Runtime/BumiMobile.Auth.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9f4f70499f67e5f4b83d4e10aa983055
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.auth/Runtime/CountryFlagDatabase.cs
+++ b/Packages/com.bumimobile.auth/Runtime/CountryFlagDatabase.cs
@@ -1,0 +1,61 @@
+// Scripts/Auth/CountryFlagDatabase.cs
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Watermelon
+{
+    [CreateAssetMenu(menuName = "Data/Country Flag Database", fileName = "CountryFlagDatabase")]
+    public class CountryFlagDatabase : ScriptableObject
+    {
+        [Serializable]
+        public struct Entry
+        {
+            [Tooltip("ISO 3166-1 alpha-2 (ID, US, JP, ...)")]
+            public string iso2;
+            [Tooltip("Nama negara (opsional). Kosongkan untuk auto (RegionInfo).")]
+            public string displayName;
+            [Tooltip("Sprite bendera untuk ISO tsb.")]
+            public Sprite flag;
+        }
+
+        [SerializeField] List<Entry> entries = new List<Entry>();
+        Dictionary<string, Entry> map;
+
+        void OnEnable() => BuildMap();
+#if UNITY_EDITOR
+        void OnValidate() => BuildMap(); // ✅ keep map fresh when editing in Inspector
+#endif
+
+        void BuildMap()
+        {
+            map = new Dictionary<string, Entry>(entries.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (var e in entries)
+            {
+                if (string.IsNullOrWhiteSpace(e.iso2)) continue;
+                string key = e.iso2.Trim().ToUpperInvariant();
+                 if (!map.ContainsKey(key)) map.Add(key, e);
+            }
+        }
+
+        public bool TryGet(string iso2, out Entry entry)
+        {
+            if (map == null) BuildMap();
+            if (string.IsNullOrWhiteSpace(iso2)) { entry = default; return false; }
+            return map.TryGetValue(iso2.Trim().ToUpperInvariant(), out entry);
+        }
+
+        public Sprite GetSprite(string iso2)
+        {
+            return TryGet(iso2, out var e) ? e.flag : null;
+        }
+
+        public string GetDisplayName(string iso2)
+        {
+            if (TryGet(iso2, out var e) && !string.IsNullOrWhiteSpace(e.displayName))
+                return e.displayName;
+
+            return string.IsNullOrWhiteSpace(iso2) ? "Unknown" : iso2.Trim().ToUpperInvariant();
+        }
+    }
+}

--- a/Packages/com.bumimobile.auth/Runtime/CountryFlagDatabase.cs
+++ b/Packages/com.bumimobile.auth/Runtime/CountryFlagDatabase.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Watermelon
+namespace BumiMobile
 {
     [CreateAssetMenu(menuName = "Data/Country Flag Database", fileName = "CountryFlagDatabase")]
     public class CountryFlagDatabase : ScriptableObject
@@ -34,7 +34,7 @@ namespace Watermelon
             {
                 if (string.IsNullOrWhiteSpace(e.iso2)) continue;
                 string key = e.iso2.Trim().ToUpperInvariant();
-                 if (!map.ContainsKey(key)) map.Add(key, e);
+                if (!map.ContainsKey(key)) map.Add(key, e);
             }
         }
 

--- a/Packages/com.bumimobile.auth/Runtime/CountryFlagDatabase.cs.meta
+++ b/Packages/com.bumimobile.auth/Runtime/CountryFlagDatabase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 48f382fb5553f5e4c84b76357c0145dd

--- a/Packages/com.bumimobile.auth/Runtime/CountryService.cs
+++ b/Packages/com.bumimobile.auth/Runtime/CountryService.cs
@@ -1,0 +1,212 @@
+﻿// CountryService (GPS ONLY VERSION)
+// ------------------------------------------------------------------
+// Disederhanakan sesuai permintaan: HANYA pakai GPS + reverse geocode (Android).
+// Tidak ada lagi: Telephony, Locale, CultureInfo, SystemLanguage heuristics.
+// Alur:
+//   InitializeAsync() -> Start LocationService -> tunggu -> ambil koordinat -> reverse geocode (Android) -> set ISO.
+//   Jika gagal / tidak izin / platform tidak didukung -> ISO = "ZZ".
+// iOS: placeholder (perlu native plugin CLGeocoder kalau ingin).
+// Manual override & cache DIPANGKAS (bisa ditambah lagi jika perlu).
+// ------------------------------------------------------------------
+
+using System;
+using UnityEngine;
+using Cysharp.Threading.Tasks;
+using UnityEngine.Networking;
+
+namespace BumiMobile
+{
+    public static class CountryService
+    {
+        public static string CountryISO { get; private set; } = "ZZ";   // ISO2 uppercase
+        // Human-friendly display name (resolved after ISO known). Falls back to ISO or "Unknown".
+        public static string CountryName { get; private set; } = "Unknown";
+        public static bool IsInitialized { get; private set; }
+        public static event Action OnCountryResolved; // dipanggil sekali saat selesai init
+
+        // Optional database for flags + custom display names
+        static CountryFlagDatabase flagDb;
+        public static CountryFlagDatabase FlagDatabase => flagDb; // public read access
+        public static void SetFlagDatabase(CountryFlagDatabase db)
+        {
+            flagDb = db;
+            if (IsInitialized)
+                CountryName = ResolveDisplayName(CountryISO);
+        }
+
+        /// <summary>Get flag sprite for current ISO or provided isoOverride (returns null if unknown).</summary>
+        public static Sprite GetFlagSprite(string isoOverride = null)
+        {
+            if (flagDb == null) return null;
+            string iso = string.IsNullOrWhiteSpace(isoOverride) ? CountryISO : isoOverride.Trim().ToUpperInvariant();
+            if (string.IsNullOrEmpty(iso) || iso == "ZZ" || iso.Length != 2) return null;
+            return flagDb.GetSprite(iso);
+        }
+
+        // ---- Config / Cache --------------------------------------------------
+        const string PREF_KEY = "country.iso.cached"; // PlayerPrefs key (string)
+        const float DEFAULT_IP_TIMEOUT = 5f;           // seconds
+        const float DEFAULT_GPS_TIMEOUT = 6f;          // seconds (existing behavior)
+
+        // ---- Public API Summary ---------------------------------------------
+        // InitializeAsync(): Idempotent. Uses cache -> IP API -> GPS fallback -> ZZ.
+        // ForceRedetectAsync(): Clears cache & re-runs full detection.
+
+        /// <summary>Inisialisasi (idempotent). Aman dipanggil berkali-kali.</summary>
+        public static async UniTask InitializeAsync(float ipTimeoutSeconds = DEFAULT_IP_TIMEOUT, float gpsTimeoutSeconds = DEFAULT_GPS_TIMEOUT)
+        {
+            if (IsInitialized) return;
+            // 1) Cache
+            if (TryLoadCachedIso(out var cached))
+            {
+                CountryISO = cached;
+                CountryName = ResolveDisplayName(CountryISO);
+                IsInitialized = true;
+                Debug.Log("[Country] Using cached ISO: " + CountryISO);
+                OnCountryResolved?.Invoke();
+                return;
+            }
+
+            // 2) IP Geolocation API
+            string isoFromIp = await ResolveViaIpApiAsync(ipTimeoutSeconds);
+            if (IsValidIso2(isoFromIp))
+            {
+                CountryISO = isoFromIp;
+                CacheIso(CountryISO);
+                CountryName = ResolveDisplayName(CountryISO);
+                IsInitialized = true;
+                Debug.Log("[Country] IP API resolved ISO: " + CountryISO);
+                OnCountryResolved?.Invoke();
+                return;
+            }
+            Debug.LogWarning("[Country] IP API failed or invalid. No fallback (API-only mode). Country remains ZZ.");
+            CountryISO = "ZZ"; // API only: stay unknown if API fails
+            CountryName = ResolveDisplayName(CountryISO);
+            IsInitialized = true;
+            OnCountryResolved?.Invoke();
+        }
+
+        /// <summary>Paksa re-detect (hapus cache + ulang full chain IP -> GPS).</summary>
+        public static async UniTask ForceRedetectAsync()
+        {
+            ClearCache();
+            IsInitialized = false;
+            CountryISO = "ZZ";
+            CountryName = ResolveDisplayName(CountryISO);
+            await InitializeAsync();
+        }
+
+        /// <summary>Manual override (misal user memilih di settings). Menyimpan ke cache.</summary>
+        // Manual override dihapus untuk versi ini. Tambah lagi jika diperlukan.
+
+        // Utilities ---------------------------------------------------------
+
+        // Cache logic dihapus.
+
+        static bool IsValidIso2(string iso) => !string.IsNullOrEmpty(iso) && iso.Length == 2 && char.IsLetter(iso[0]) && char.IsLetter(iso[1]);
+
+        // ---- Cache Helpers ---------------------------------------------------
+        static bool TryLoadCachedIso(out string iso)
+        {
+            iso = null;
+            if (!PlayerPrefs.HasKey(PREF_KEY)) return false;
+            var val = PlayerPrefs.GetString(PREF_KEY, null);
+            if (IsValidIso2(val)) { iso = val.ToUpperInvariant(); return true; }
+            return false;
+        }
+        static void CacheIso(string iso)
+        {
+            if (!IsValidIso2(iso)) return;
+            PlayerPrefs.SetString(PREF_KEY, iso.ToUpperInvariant());
+            PlayerPrefs.Save();
+        }
+        public static void ClearCache()
+        {
+            if (PlayerPrefs.HasKey(PREF_KEY)) { PlayerPrefs.DeleteKey(PREF_KEY); PlayerPrefs.Save(); }
+        }
+
+        // ---- IP Geo ---------------------------------------------------------
+        // Using https://ipwho.is/ (no key) -> field country_code (ISO2) & success boolean.
+        [Serializable]
+        class IpWhoResponse { public bool success; public string country_code; }
+
+        static async UniTask<string> ResolveViaIpApiAsync(float timeoutSeconds)
+        {
+            try
+            {
+                using var req = UnityWebRequest.Get("https://ipwho.is/");
+                req.timeout = Mathf.CeilToInt(timeoutSeconds);
+                var op = req.SendWebRequest();
+                while (!op.isDone)
+                    await UniTask.Yield();
+
+#if UNITY_2020_2_OR_NEWER
+                if (req.result != UnityWebRequest.Result.Success)
+                {
+                    Debug.LogWarning("[Country] IP API network error: " + req.error);
+                    return null;
+                }
+#else
+                if (req.isNetworkError || req.isHttpError)
+                {
+                    Debug.LogWarning("[Country] IP API network error: " + req.error);
+                    return null;
+                }
+#endif
+                var json = req.downloadHandler.text;
+                if (string.IsNullOrWhiteSpace(json)) return null;
+                IpWhoResponse resp = null;
+                try { resp = JsonUtility.FromJson<IpWhoResponse>(json); } catch { }
+                if (resp != null && resp.success && IsValidIso2(resp.country_code))
+                    return resp.country_code.ToUpperInvariant();
+                Debug.LogWarning("[Country] IP API parse/invalid response: " + json);
+                return null;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[Country] IP API exception: " + e.Message);
+                return null;
+            }
+        }
+
+
+        /// <summary>
+        /// Optional: refine country via GPS + reverse geocode (Android Geocoder) tanpa memaksa user setuju terlalu cepat.
+        /// Hanya dipanggil jika ingin akurasi lebih tinggi. Timeout minimal agar tidak menggantung.
+        /// </summary>
+        // EnhanceWithGpsAsync dihapus: deteksi sudah langsung saat InitializeAsync.
+
+        // ----- Detection Layers -------------------------------------------
+        // GPS & reverse geocode code removed (API-only mode)
+
+        // ------------------------------------------------------------------
+        // One-shot location capture for ProfileController (stores into ProfileSave)
+        // ------------------------------------------------------------------
+#if BUMIMOBILE_PROFILE_SAVE
+        public static UniTask CaptureLocationOnceAsync(ProfileSave save, float timeoutSeconds = 6f)
+        {
+            if (save == null) return UniTask.CompletedTask;
+            save.LocationPermissionAsked = true;
+            // In API-only mode we don't access GPS; just copy current CountryISO snapshot.
+            save.LocationPermissionGranted = false; // we didn't ask
+            if (IsValidIso2(CountryISO)) save.LastLocationCountryISO = CountryISO;
+            return UniTask.CompletedTask;
+        }
+#endif
+
+        // ---- Display Name Resolution ---------------------------------------
+        static string ResolveDisplayName(string iso)
+        {
+            if (string.IsNullOrWhiteSpace(iso)) return "Unknown";
+            if (!IsValidIso2(iso) || string.Equals(iso, "ZZ", StringComparison.OrdinalIgnoreCase)) return "Unknown";
+
+            if (flagDb != null)
+            {
+                var name = flagDb.GetDisplayName(iso);
+                if (!string.IsNullOrWhiteSpace(name)) return name;
+            }
+
+            return iso.ToUpperInvariant();
+        }
+    }
+}

--- a/Packages/com.bumimobile.auth/Runtime/CountryService.cs.meta
+++ b/Packages/com.bumimobile.auth/Runtime/CountryService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 256eee8b563fe8d48a9c75829fda27a5

--- a/Packages/com.bumimobile.auth/package.json
+++ b/Packages/com.bumimobile.auth/package.json
@@ -12,9 +12,6 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.cysharp.unitask": "2.5.10",
-    "com.google.firebase.auth": "11.8.1",
-    "com.google.firebase.app": "11.8.1",
-    "com.google.play.games": "0.11.01"
+    "com.bumimobile.core": "0.1.1"
   }
 }

--- a/Packages/com.bumimobile.auth/package.json
+++ b/Packages/com.bumimobile.auth/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "com.bumimobile.auth",
+  "displayName": "Bumi Mobile Auth",
+  "version": "0.1.1",
+  "unity": "2021.3",
+  "description": "Authentication scaffolding for the Bumi Mobile framework.",
+  "keywords": [
+    "bumi",
+    "auth",
+    "login",
+    "session"
+  ],
+  "category": "Framework",
+  "dependencies": {
+    "com.cysharp.unitask": "2.5.10",
+    "com.google.firebase.auth": "11.8.1",
+    "com.google.firebase.app": "11.8.1",
+    "com.google.play.games": "0.11.01"
+  }
+}

--- a/Packages/com.bumimobile.auth/package.json
+++ b/Packages/com.bumimobile.auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.auth",
   "displayName": "Bumi Mobile Auth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "unity": "2021.3",
   "description": "Authentication scaffolding for the Bumi Mobile framework.",
   "keywords": [

--- a/Packages/com.bumimobile.auth/package.json.meta
+++ b/Packages/com.bumimobile.auth/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: be3a85879cebeb74bb9f1152ed97fc05
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -13,10 +13,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.cysharp.unitask": "2.5.10",
-        "com.google.firebase.auth": "11.8.1",
-        "com.google.firebase.app": "11.8.1",
-        "com.google.play.games": "0.11.01"
+        "com.bumimobile.core": "0.1.1"
       }
     },
     "com.bumimobile.core": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -8,6 +8,17 @@
         "com.bumimobile.core": "0.1.1"
       }
     },
+    "com.bumimobile.auth": {
+      "version": "file:com.bumimobile.auth",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {
+        "com.cysharp.unitask": "2.5.10",
+        "com.google.firebase.auth": "11.8.1",
+        "com.google.firebase.app": "11.8.1",
+        "com.google.play.games": "0.11.01"
+      }
+    },
     "com.bumimobile.core": {
       "version": "file:com.bumimobile.core",
       "depth": 0,

--- a/README.md
+++ b/README.md
@@ -17,23 +17,24 @@ Modular Unity packages for mobile & hyper-casual games. Install the core once, t
 
 ## 📦 Module Overview
 
-| Package | What it covers |
-| --- | --- |
-| **Core** (`com.bumimobile.core`) | Base inspectors, tween utilities, initializer helpers, custom editor styles. Installed by default. |
-| **Audio** | Lightweight BGM/SFX routing, init module, and editor config. |
-| **Currency** | Currency definitions, balances, and formatters. |
-| **Defines** | Shared scripting define presets and toggles. |
-| **Haptic** | Haptic feedback abstraction for iOS & Android. |
-| **Localization** | String tables, runtime localization helpers, editor importers. |
-| **Monetization** | Ads + IAP settings (with tabbed inspector) and runtime glue. |
-| **NativeShare** | Mobile share sheets for screenshots/text. |
-| **Pool** | Object pooling service and helpers. |
-| **Push Notification** | Mobile push initialization hooks. |
-| **Reward** | Daily/event reward data structures. |
-| **Save** | Save-system wrapper (PlayerPrefs + serializers). |
-| **Skins** | Unlockable skin manager and sample UI. |
-| **UI** | Common popups, loading views, toasts, etc. |
-| **Utilities** | Extra helpers shared by multiple modules. |
+| Package                          | What it covers                                                                                                                                                         |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Core** (`com.bumimobile.core`) | Base inspectors, tween utilities, initializer helpers, custom editor styles. Installed by default.                                                                     |
+| **Auth** (`com.bumimobile.auth`) | Firebase Auth bootstrap with optional Google Play Games v2 sign-in; requires external SDKs and define flags (`BUMI_AUTH_HAS_FIREBASE`, optional `BUMI_AUTH_HAS_GPGS`). |
+| **Audio**                        | Lightweight BGM/SFX routing, init module, and editor config.                                                                                                           |
+| **Currency**                     | Currency definitions, balances, and formatters.                                                                                                                        |
+| **Defines**                      | Shared scripting define presets and toggles.                                                                                                                           |
+| **Haptic**                       | Haptic feedback abstraction for iOS & Android.                                                                                                                         |
+| **Localization**                 | String tables, runtime localization helpers, editor importers.                                                                                                         |
+| **Monetization**                 | Ads + IAP settings (with tabbed inspector) and runtime glue.                                                                                                           |
+| **NativeShare**                  | Mobile share sheets for screenshots/text.                                                                                                                              |
+| **Pool**                         | Object pooling service and helpers.                                                                                                                                    |
+| **Push Notification**            | Mobile push initialization hooks.                                                                                                                                      |
+| **Reward**                       | Daily/event reward data structures.                                                                                                                                    |
+| **Save**                         | Save-system wrapper (PlayerPrefs + serializers).                                                                                                                       |
+| **Skins**                        | Unlockable skin manager and sample UI.                                                                                                                                 |
+| **UI**                           | Common popups, loading views, toasts, etc.                                                                                                                             |
+| **Utilities**                    | Extra helpers shared by multiple modules.                                                                                                                              |
 
 > Tween, inspector extensions, and initializer logic now live inside Core, so they no longer appear as standalone packages.
 
@@ -47,8 +48,8 @@ Modular Unity packages for mobile & hyper-casual games. Install the core once, t
 1. In Unity open `Window ▸ Bumi Mobile Core ▸ Package Manager`.
 1. For each module:
 
-    - Pick the desired tag/branch (e.g., `audio-v0.2.0`, `dev`, `main`).
-    - Click `Install` or `Update`. The window uses Unity’s Package Manager API and pins entries inside `Packages/manifest.json`.
+   - Pick the desired tag/branch (e.g., `audio-v0.2.0`, `dev`, `main`).
+   - Click `Install` or `Update`. The window uses Unity’s Package Manager API and pins entries inside `Packages/manifest.json`.
 
 1. Already installed modules show their current version and can’t be re-downloaded until you change the target version.
 
@@ -68,14 +69,17 @@ Add Git dependencies directly in `Packages/manifest.json`:
 
 Save the file and Unity will resolve each package. Keep `Packages/packages-lock.json` under version control so teammates get identical revisions.
 
+### SDK-backed modules
+
+Some packages require external SDKs that Unity will not install automatically:
+
+- **Auth** — Install Firebase Core/Auth (`com.google.firebase.app`, `com.google.firebase.auth`) and, for Android Google sign-in, Google Play Games v2 (`com.google.play.games`). After importing these SDKs add scripting defines `BUMI_AUTH_HAS_FIREBASE` (required) and `BUMI_AUTH_HAS_GPGS` (optional) under _Project Settings ▸ Player ▸ Scripting Define Symbols_.
+
 ---
 
 ## 🧰 Core Tools
 
 ### Project Setup
-
-- Menu: `Window ▸ Bumi Mobile Core ▸ Prepare Project`
-- Generates the recommended folder layout, initializer prefab, and scenes.
 
 ```text
 Assets/
@@ -94,7 +98,6 @@ Assets/
   ├── Scripts/
   ├── Shaders/
   └── Textures/
-
 ```
 
 ### Core Settings Asset


### PR DESCRIPTION
This pull request introduces the initial implementation of the Bumi Mobile Auth package, providing authentication and country identification features for Bumi Mobile projects. The package supports Google Play Games sign-in, Firebase authentication (including anonymous fallback), and country flag resolution, with clear documentation and support for conditional compilation. The most important changes are grouped below:

**Authentication and Initialization**

* Added `AuthService` static class, which wraps Google Play Games v2 and Firebase Auth sign-in, supports anonymous fallback, and exposes sign-in/out methods and user state properties. The implementation includes stub fallback when Firebase SDK is not present. (`Runtime/AuthService.cs`, `Runtime/AuthService.cs.meta`) [[1]](diffhunk://#diff-23d963e0b4b1368ca2dcb0ea43276c6a70065d2b774a3a415fa15698f9867b04R1-R377) [[2]](diffhunk://#diff-3aef8bf25d0d46bc171962bf12c4075b42d333cbc929422d4d2bf24544c78a8dR1-R2)
* Added `AuthenticatedInitModule` ScriptableObject, integrating authentication (with timeout, skip, and disable flows) into the core initializer pipeline, and supporting country flag assignment. (`Runtime/AuthenticatedInitModule.cs`, `Runtime/AuthenticatedInitModule.cs.meta`) [[1]](diffhunk://#diff-44bfb73bc3d1f19aa882be677c6dd370c10beffedb5b2bdfc48addc9d8c8a23aR1-R118) [[2]](diffhunk://#diff-41efcd9d88ce72a79afff07c78057549a0f64f9b872ab90ab43d3e957c837462R1-R2)

**Country Identification**

* Introduced `CountryService` and `CountryFlagDatabase` for resolving player country via IP lookup and mapping ISO country codes to flag sprites and localized names. (Documented in `README.md`)

**Documentation and Versioning**

* Added comprehensive documentation in `README.md`, detailing package features, setup instructions, scripting define symbols, and integration steps. [[1]](diffhunk://#diff-f8c976be2cf1fcab0581f406b836b69bf2438c5318ffa0d7940edb89a97ae067R1-R51) [[2]](diffhunk://#diff-c3a59756533343d0474fdb42ea5a02baafa8c740b35da961fd3dfa32326499cfR1-R7)
* Established a `CHANGELOG.md` following Keep a Changelog and Semantic Versioning, documenting the initial release, dependency declarations, and compile flag options. (`CHANGELOG.md`, `CHANGELOG.md.meta`) [[1]](diffhunk://#diff-e0088c626cdf5cf604f28bd859d6cfa20573448fc0d6aa86008356506ec43826R1-R31) [[2]](diffhunk://#diff-3a1693351f7218b58bb29634251ba6a2a1d5197f61af21fbf9e7e8a7c4018696R1-R7)

**Unity Package Configuration**

* Added assembly definition `BumiMobile.Auth.asmdef` with conditional compilation for Google Play Games and Firebase, and referenced dependencies.
* Added Unity `.meta` files for all new assets and folders. (`Runtime.meta`)