### PR TITLE
Feat : Add identifier-based audio catalog and helpers

### DIFF
--- a/Packages/com.bumimobile.audio/CHANGELOG.md
+++ b/Packages/com.bumimobile.audio/CHANGELOG.md
@@ -8,6 +8,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 - (Add unreleased changes here)
 
+## [0.1.1] - 2025-12-01
+
+### Added
+
+- Identifier-based `AudioClips` catalog with grouped entries, making it easier to add new clips without editing code.
+- `AudioClipReference` struct and `AudioController.TryPlaySound` helpers for resolving clips by id.
+
+### Changed
+
+- Legacy `buttonSound` now resolves to the `ui/button` entry in the catalog so existing code keeps working while new clips use the modular flow.
+
 ## [0.1.0] - 2025-11-14
 
 ### Added

--- a/Packages/com.bumimobile.audio/README.md
+++ b/Packages/com.bumimobile.audio/README.md
@@ -1,0 +1,93 @@
+# Bumi Mobile Audio
+
+Audio playback, pooling, and configuration helpers used across Bumi Mobile projects. The package provides a catalog-driven workflow for organizing sound effects, pooled playback utilities, and init-module glue that keeps setup consistent between games.
+
+## Features
+
+- Identifier-based `AudioClips` catalog with grouped slots, automatic lookup cache, and backwards-compatible button click support.
+- `AudioClipReference` struct for serializing catalog references without hard-coding `AudioClip` assets inside prefabs.
+- `AudioController` static facade with pooled `AudioSource`s, default 2D/3D settings, clip lookup helpers, and `TryPlaySound` shortcuts.
+- Optional `AudioInitModule` that plugs into the Core initializer to bootstrap the listener, catalog, and source pool at startup.
+- Volume routing per `AudioType`, persistence via the Save module (when `MODULE_SAVE` is available), and change callbacks for UI sliders.
+- Utilities such as `AudioClipHandler`, `MusicSource`, and tween-friendly fade helpers for advanced UX flows.
+
+## Requirements
+
+- Unity 2021.3 or newer.
+- `com.bumimobile.core` (the initializer, module registry, and shared utilities live there).
+- Optional: `MODULE_SAVE` define plus the Save module if you want `AudioController` volumes to persist between sessions.
+
+## Getting Started
+
+1. **Create an `AudioClips` catalog**
+   - Project window ▸ Create ▸ *Audio Clips* (searchable via the asset menu). Populate groups (UI, Gameplay, etc.) and add slots with unique identifiers such as `ui/button` or `fx/explosion_big`.
+   - The legacy `buttonSound` field resolves to the `ui/button` slot so existing references keep working.
+
+2. **Add the Audio Init Module (recommended)**
+   - Open your `ProjectInitSettings` asset (from `com.bumimobile.core`).
+   - Click **Add Module** and select **Audio Controller**.
+   - Assign the `AudioClips` catalog and configure the pool size plus optional 3D defaults (max distance, spread, rolloff curve).
+   - The initializer now bootstraps `AudioController` before the rest of your gameplay systems run.
+
+3. **Manual initialization (alternative)**
+
+```csharp
+[SerializeField] private AudioClips catalog;
+[SerializeField] private int poolSize = 8;
+
+void Awake()
+{
+    AudioController.OverrideDefault3DAudioSettings(30f, 180f, AnimationCurve.EaseInOut(0, 1, 1, 0));
+    AudioController.Init(catalog, poolSize);
+}
+```
+
+## Using the Catalog at Runtime
+
+- Fetch clips directly: `var clip = AudioController.GetClip("ui/button");`
+- Fire-and-forget playback with validation:
+
+```csharp
+AudioController.TryPlaySound("ui/button");
+AudioController.TryPlaySound("fx/explosion_small", transform.position, 0.8f, 1.1f);
+```
+
+- Serialize safe references inside prefabs or scriptable objects:
+
+```csharp
+[SerializeField] private AudioClipReference rewardSound;
+
+public void OnRewardGranted()
+{
+    if (rewardSound.TryResolve(out var clip))
+    {
+        AudioController.PlaySound(clip);
+    }
+}
+```
+
+- Iterate every slot for tooling/integration:
+
+```csharp
+foreach (var slot in audioClips.EnumerateSlots())
+{
+    Debug.Log($"{slot.Id} -> {slot.DisplayName}");
+}
+```
+
+## Volume, Music, and Advanced Playback
+
+- Call `AudioController.SetVolume(AudioType.Sound, sliderValue);` to update SFX levels; subscribe to `AudioController.VolumeChanged` for UI feedback.
+- When the Save module is present the current volumes are serialized via `AudioSave`, so `SetVolume` automatically flags data for persistence.
+- Add a `MusicSource` to scene singletons. Call `musicSource.Init()` once, optionally `SetAsDefault()`/`Activate()` to control cross-fading between multiple theme tracks.
+- Use `AudioClipHandler` components for designer-friendly knobs: it supports cooldowns, dynamic pitch stepping, dedicated `AudioSource`s, and tween-friendly fades.
+
+## Troubleshooting
+
+- `TryPlaySound` logs a warning if the clip identifier is missing. Keep identifiers unique per catalog slot to avoid silent failures.
+- If nothing plays, verify the Audio Init Module ran (check the `Initializer` prefab) or ensure `AudioController.Init` was called manually before any playback requests.
+- The listener is auto-created when the controller initializes. Use `AudioController.AttachAudioListener` to parent it to a camera/character rig when needed.
+
+## License
+
+See the repository root `LICENSE` file for licensing terms.

--- a/Packages/com.bumimobile.audio/Runtime/AudioClipReference.cs
+++ b/Packages/com.bumimobile.audio/Runtime/AudioClipReference.cs
@@ -1,0 +1,39 @@
+using System;
+using UnityEngine;
+
+namespace BumiMobile
+{
+    /// <summary>
+    /// Lightweight reference that stores a clip id and resolves it against a catalog at runtime.
+    /// </summary>
+    [Serializable]
+    public struct AudioClipReference
+    {
+        [SerializeField]
+        private AudioClips catalog;
+
+        [SerializeField]
+        [Tooltip("Identifier defined inside the AudioClips catalog (e.g. 'ui/button').")]
+        private string clipId;
+
+        public string ClipId => clipId;
+        public AudioClips Catalog => catalog;
+
+        public AudioClip Resolve(AudioClips overrideCatalog = null)
+        {
+            AudioClips source = overrideCatalog ?? catalog ?? AudioController.AudioClips;
+            return source != null ? source.GetClipOrNull(clipId) : null;
+        }
+
+        public bool TryResolve(out AudioClip clip, AudioClips overrideCatalog = null)
+        {
+            clip = Resolve(overrideCatalog);
+            return clip != null;
+        }
+
+        public override string ToString()
+        {
+            return string.IsNullOrEmpty(clipId) ? base.ToString() : clipId;
+        }
+    }
+}

--- a/Packages/com.bumimobile.audio/Runtime/AudioClipReference.cs.meta
+++ b/Packages/com.bumimobile.audio/Runtime/AudioClipReference.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 31faf24b79be95b4e9636d22fbb247e0

--- a/Packages/com.bumimobile.audio/Runtime/AudioController.cs
+++ b/Packages/com.bumimobile.audio/Runtime/AudioController.cs
@@ -120,9 +120,9 @@ namespace BumiMobile
         /// </summary>
         public static void ReleaseSources()
         {
-            foreach(AudioSourceCase sourceCase in audioSourcesPool)
+            foreach (AudioSourceCase sourceCase in audioSourcesPool)
             {
-                if(sourceCase.IsPlaying)
+                if (sourceCase.IsPlaying)
                 {
                     sourceCase.AudioSource.Stop();
                 }
@@ -158,9 +158,40 @@ namespace BumiMobile
             sourceCase.Play(clip, volumePercentage, AudioType.Sound);
         }
 
+        public static AudioClip GetClip(string clipId)
+        {
+            return audioClips != null ? audioClips.GetClipOrNull(clipId) : null;
+        }
+
+        public static bool TryPlaySound(string clipId, float volumePercentage = 1.0f, float pitch = 1.0f)
+        {
+            var clip = GetClip(clipId);
+            if (clip == null)
+            {
+                Debug.LogWarning($"[AudioController] Clip '{clipId}' was not found in the catalog.");
+                return false;
+            }
+
+            PlaySound(clip, volumePercentage, pitch);
+            return true;
+        }
+
+        public static bool TryPlaySound(string clipId, Vector3 position, float volumePercentage = 1.0f, float pitch = 1.0f)
+        {
+            var clip = GetClip(clipId);
+            if (clip == null)
+            {
+                Debug.LogWarning($"[AudioController] Clip '{clipId}' was not found in the catalog.");
+                return false;
+            }
+
+            PlaySound(clip, position, volumePercentage, pitch);
+            return true;
+        }
+
         private static AudioSourceCase GetAudioSource()
         {
-            foreach(AudioSourceCase audioSource in audioSourcesPool)
+            foreach (AudioSourceCase audioSource in audioSourcesPool)
             {
                 if (!audioSource.IsPlaying)
                 {

--- a/Packages/com.bumimobile.audio/Runtime/MD_AudioClips.cs
+++ b/Packages/com.bumimobile.audio/Runtime/MD_AudioClips.cs
@@ -1,13 +1,158 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace BumiMobile
 {
+    /// <summary>
+    /// Catalog of reusable audio clips grouped by a readable identifier.
+    /// </summary>
     [CreateAssetMenu(fileName = "Audio Clips", menuName = "Data/Core/Audio Clips")]
     public class AudioClips : ScriptableObject
     {
-        [BoxGroup("UI", "UI")]
-        public AudioClip buttonSound;
+        /// <summary>Default key used by legacy button click sounds.</summary>
+        public const string ButtonSoundKey = "ui/button";
+
+        [SerializeField]
+        private List<AudioClipGroup> groups = new List<AudioClipGroup> { new AudioClipGroup("UI") };
+
+
+
+        private Dictionary<string, AudioClipSlot> lookup;
+
+        /// <summary>All configured clip groups as shown in the inspector.</summary>
+        public IReadOnlyList<AudioClipGroup> Groups => groups;
+
+        /// <summary>Backwards compatible accessor for the old button click field.</summary>
+        public AudioClip buttonSound => GetClipOrNull(ButtonSoundKey);
+
+        /// <summary>Try to resolve a clip by id defined in the catalog.</summary>
+        public bool TryGetClip(string clipId, out AudioClip clip)
+        {
+            clip = GetClipOrNull(clipId);
+            return clip != null;
+        }
+
+        /// <summary>Return a clip by id or null when the slot does not exist.</summary>
+        public AudioClip GetClipOrNull(string clipId)
+        {
+            if (TryGetSlot(clipId, out var slot))
+            {
+                return slot.Clip;
+            }
+
+            return null;
+        }
+
+        /// <summary>Enumerate all slots for tooling/integration purposes.</summary>
+        public IEnumerable<AudioClipSlot> EnumerateSlots()
+        {
+            EnsureLookup();
+            return lookup.Values;
+        }
+
+        /// <summary>Resolve an entire slot (clip + metadata) by id.</summary>
+        public bool TryGetSlot(string clipId, out AudioClipSlot slot)
+        {
+            if (string.IsNullOrWhiteSpace(clipId))
+            {
+                slot = null;
+                return false;
+            }
+
+            EnsureLookup();
+            return lookup.TryGetValue(clipId, out slot) && slot != null;
+        }
+
+        private void OnEnable() => EnsureLookup(force: true);
+
+        private void OnValidate() => EnsureLookup(force: true);
+
+        private void EnsureLookup(bool force = false)
+        {
+            if (!force && lookup != null)
+            {
+                return;
+            }
+
+            lookup = new Dictionary<string, AudioClipSlot>(StringComparer.OrdinalIgnoreCase);
+            foreach (var group in groups)
+            {
+                if (group == null)
+                {
+                    continue;
+                }
+
+                foreach (var slot in group.Clips)
+                {
+                    if (slot == null)
+                    {
+                        continue;
+                    }
+
+                    var key = slot.Id;
+                    if (string.IsNullOrWhiteSpace(key))
+                    {
+                        continue;
+                    }
+
+                    if (!lookup.ContainsKey(key))
+                    {
+                        lookup.Add(key, slot);
+                    }
+                }
+            }
+        }
+
+        [Serializable]
+        public class AudioClipGroup
+        {
+            [SerializeField]
+            private string groupName = "Group";
+
+            [SerializeField]
+            private List<AudioClipSlot> clips = new List<AudioClipSlot>();
+
+            public AudioClipGroup() { }
+
+            public AudioClipGroup(string groupName)
+            {
+                this.groupName = groupName;
+            }
+
+            public string GroupName => groupName;
+            public List<AudioClipSlot> Clips => clips;
+        }
+
+        [Serializable]
+        public class AudioClipSlot
+        {
+            [SerializeField]
+            [Tooltip("Unique identifier used when requesting the clip in code (e.g. 'ui/button').")]
+            private string id = "ui/button";
+
+            [SerializeField]
+            private string displayName = "Button";
+
+            [SerializeField]
+            private AudioClip clip;
+
+            public AudioClipSlot() { }
+
+            public AudioClipSlot(string id, string displayName, AudioClip clip)
+            {
+                this.id = id;
+                this.displayName = displayName;
+                this.clip = clip;
+            }
+
+            public string Id => id;
+            public string DisplayName => displayName;
+            public AudioClip Clip => clip;
+
+            public override string ToString() => string.IsNullOrEmpty(displayName) ? id : $"{displayName} ({id})";
+        }
     }
 }
 


### PR DESCRIPTION
Introduces an AudioClips catalog with grouped entries and identifier-based lookup, enabling modular sound management. Adds AudioClipReference struct for serializable clip references, and AudioController helpers for resolving and playing sounds by id. Legacy buttonSound now resolves to the catalog for backward compatibility.