### PR TITLE
fix : Add README and auto module defines to monetization

### DIFF
--- a/Packages/com.bumimobile.audio/README.md
+++ b/Packages/com.bumimobile.audio/README.md
@@ -20,10 +20,12 @@ Audio playback, pooling, and configuration helpers used across Bumi Mobile proje
 ## Getting Started
 
 1. **Create an `AudioClips` catalog**
-   - Project window ▸ Create ▸ *Audio Clips* (searchable via the asset menu). Populate groups (UI, Gameplay, etc.) and add slots with unique identifiers such as `ui/button` or `fx/explosion_big`.
+
+   - Project window ▸ Create ▸ _Audio Clips_ (searchable via the asset menu). Populate groups (UI, Gameplay, etc.) and add slots with unique identifiers such as `ui/button` or `fx/explosion_big`.
    - The legacy `buttonSound` field resolves to the `ui/button` slot so existing references keep working.
 
 2. **Add the Audio Init Module (recommended)**
+
    - Open your `ProjectInitSettings` asset (from `com.bumimobile.core`).
    - Click **Add Module** and select **Audio Controller**.
    - Assign the `AudioClips` catalog and configure the pool size plus optional 3D defaults (max distance, spread, rolloff curve).

--- a/Packages/com.bumimobile.audio/README.md.meta
+++ b/Packages/com.bumimobile.audio/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5e6ac77e111da7f468808b6f912a8327
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.monetization/CHANGELOG.md
+++ b/Packages/com.bumimobile.monetization/CHANGELOG.md
@@ -8,6 +8,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 - (Add unreleased changes here)
 
+## [0.1.2] - 2025-12-01
+
+### Added
+
+- README documenting monetization features, providers, and setup guidance.
+
+### Changed
+
+- `BumiMobile.Monetization.asmdef` now adds `MODULE_ADMOB`, `MODULE_LEVELPLAY`, and `MODULE_UNITYADS` automatically when their packages are present.
+
 ## [0.1.0] - 2025-11-14
 
 ### Added

--- a/Packages/com.bumimobile.monetization/README.md
+++ b/Packages/com.bumimobile.monetization/README.md
@@ -1,0 +1,98 @@
+# Bumi Mobile Monetization
+
+Unified ads + in-app purchase orchestration for Bumi Mobile projects. This package wraps the initialization pipeline, consent gating, provider abstractions, and helper APIs so individual games only wire the high-level settings.
+
+## Features
+
+- **Single settings asset** (`MonetizationSettings`) that embeds both `AdsSettings` and `IAPSettings`, including privacy links, debug/test devices, and enable/disable toggles.
+- **Initializer module** (`MonetizationInitModule`) that plugs into the Core startup pipeline and bootstraps `Monetization`, `AdsManager`, and `IAPManager` in the correct order.
+- **Ad provider abstraction**: `AdProviderHandler` implementations for AdMob, Unity Ads Legacy, LevelPlay, and a Dummy fallback. Each handles banners, interstitials, and rewarded videos with shared retry logic.
+- **Consent + platform tasks**: optional UMP (GDPR) + IDFA `LoadingTask`s gate ad initialization until the required prompts finish; forced-ad persistence integrates with the Save module when `MODULE_SAVE` is present.
+- **IAP wrapper layer** over Unity IAP that exposes product lookups by `ProductKeyType`, purchase events, restore helpers, and editor tooling (`IAPSettings`, `IAPItem`, `ProductData`).
+- **Editor UX**: custom inspectors for Monetization/Ads/IAP settings, provider-specific containers (AdMob IDs, Unity Ads placements, LevelPlay keys), and convenience menu items to generate the nested assets.
+- **Auto module defines**: the runtime asmdef now emits `MODULE_ADMOB`, `MODULE_LEVELPLAY`, and `MODULE_UNITYADS` as soon as their Unity packages are installed, keeping the relevant code paths enabled without manual define management.
+
+## Requirements
+
+- Unity **2021.3** or newer.
+- `com.bumimobile.core` 0.1.1+ for the initializer, module registry, and helper utilities.
+- Optional SDKs:
+  - `com.google.ads.mobile` (Google Mobile Ads / AdMob).
+  - `com.ironsource.unity` (ironSource LevelPlay).
+  - `com.unity.ads` (Unity Ads, used by the legacy handler).
+  - `com.unity.purchasing` if you plan to use IAPs (`MODULE_IAP`).
+
+## Getting Started
+
+1. **Create Monetization Settings**
+
+   - `Assets ▸ Create ▸ Data ▸ Core ▸ Monetization Settings` generates a ScriptableObject that already contains embedded `Ads Settings` and `IAP Settings` sub-assets. Fill in privacy/terms URLs and any test devices.
+   - In the Ads tab pick which `AdProvider` backs banners, interstitials, and rewarded videos. Configure provider containers (IDs, placements, consent options, LevelPlay banner sizes, etc.). Toggle UMP/IDFA if you want the built-in consent flow.
+   - In the IAP tab define products (`IAPItem` entries) and map them to `ProductKeyType`s used in code.
+
+2. **Wire the initializer**
+
+   - Add a `MonetizationInitModule` asset to your `ProjectInitSettings` (via the Core initializer UI). Assign the Monetization Settings asset created above.
+   - During startup the module calls `Monetization.Init(settings)`, `AdsManager.Init(settings)`, and `IAPManager.Init(settings)`. Optional UMP/IDFA loading tasks run before ad providers are touched.
+
+3. **Optional: manual bootstrap**
+
+```csharp
+[SerializeField] private MonetizationSettings monetizationSettings;
+
+IEnumerator Start()
+{
+    Monetization.Init(monetizationSettings);
+    AdsManager.Init(monetizationSettings);
+    IAPManager.Init(monetizationSettings);
+    yield return null;
+    AdsManager.TryToLoadFirstAds();
+}
+```
+
+## Runtime Usage
+
+- **Ads**
+
+  - Request/show ads through `AdsManager`: `AdsManager.RequestInterstitial();`, `AdsManager.ShowInterstitial(OnInterstitialClosed);`, `AdsManager.TryToLoadFirstAds();`.
+  - Subscribe to module events: `AdsManager.AdLoaded += OnAdLoaded;`, `AdsManager.AdProviderInitialized += OnProviderReady;`.
+  - Force banner visibility: `AdsManager.ShowBanner();` / `AdsManager.HideBanner();`.
+
+- **Purchasing**
+
+```csharp
+void Awake()
+{
+    IAPManager.PurchaseCompleted += OnPurchaseSuccess;
+    IAPManager.PurchaseFailed += OnPurchaseFailed;
+}
+
+public void BuyNoAds()
+{
+    IAPManager.BuyProduct(ProductKeyType.NoAds);
+}
+```
+
+- **Product data helpers**
+
+```csharp
+var gemPack = IAPManager.GetProductData(ProductKeyType.GemsPackLarge);
+priceLabel.text = gemPack == null ? "--" : $"{gemPack.ISOCurrencyCode} {gemPack.Price}";
+```
+
+## Consent & Platform Nuances
+
+- Enable **UMP** in `AdsSettings` to automatically show the Consent Management Platform. Debug geography and TFUA flags are exposed in the inspector. `UMPLoadingTask` blocks ad initialization until consent is resolved.
+- Enable **IDFA** to request tracking authorization on iOS via `IDFALoadingTask`. Ads will only start after the tracking status is determined.
+- When AdMob/Unity Ads/LevelPlay packages are installed, the asmdef emits `MODULE_ADMOB`, `MODULE_UNITYADS`, and `MODULE_LEVELPLAY` so the relevant handlers compile without extra defines.
+
+## Troubleshooting
+
+- `AdsManager` logs warnings when a provider is selected in `AdsSettings` but not installed or initialized—double-check the provider SDK and defines.
+- If ads never load, make sure UMP/IDFA tasks finished (watch the GameLoading tasks list) or temporarily disable those toggles while debugging.
+- IAP calls require the Unity Purchasing package; without it `MODULE_IAP` stays undefined and the dummy wrapper is used.
+- Use the verbose logging flag on the Monetization settings asset to surface detailed provider events in the console.
+
+## License
+
+See the root `LICENSE` file for licensing details.

--- a/Packages/com.bumimobile.monetization/Runtime/BumiMobile.Monetization.asmdef
+++ b/Packages/com.bumimobile.monetization/Runtime/BumiMobile.Monetization.asmdef
@@ -11,5 +11,22 @@
   "precompiledReferences": [],
   "autoReferenced": true,
   "defineConstraints": [],
+  "versionDefines": [
+    {
+      "name": "com.google.ads.mobile",
+      "expression": "0.0.0",
+      "define": "MODULE_ADMOB"
+    },
+    {
+      "name": "com.ironsource.unity",
+      "expression": "0.0.0",
+      "define": "MODULE_LEVELPLAY"
+    },
+    {
+      "name": "com.unity.ads",
+      "expression": "0.0.0",
+      "define": "MODULE_UNITYADS"
+    }
+  ],
   "noEngineReferences": false
 }

--- a/Packages/com.bumimobile.monetization/package.json
+++ b/Packages/com.bumimobile.monetization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.monetization",
   "displayName": "Bumi Mobile Monetization",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "unity": "2021.3",
   "description": "Ads, purchasing, and monetization orchestration for Bumi Mobile projects.",
   "keywords": [


### PR DESCRIPTION
Added a comprehensive README for the monetization package detailing features, setup, and usage. Updated the asmdef to automatically emit MODULE_ADMOB, MODULE_LEVELPLAY, and MODULE_UNITYADS when their respective packages are present. Bumped package version to 0.1.2 and updated changelog accordingly. Minor formatting improvements to audio README.