### PR TITLE
Feat : Firebase save

### DIFF
--- a/Packages/com.bumimobile.audio/README.md.meta
+++ b/Packages/com.bumimobile.audio/README.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
+guid: 5e6ac77e111da7f468808b6f912a8327
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Packages/com.bumimobile.core/Editor/CoreSettings/CoreEditor.cs
+++ b/Packages/com.bumimobile.core/Editor/CoreSettings/CoreEditor.cs
@@ -26,7 +26,7 @@ namespace BumiMobile
         public static Color AdsDummyBackgroundColor { get; private set; } = new Color(0.2f, 0.2f, 0.3f);
         public static Color AdsDummyMainColor { get; private set; } = new Color(0.2f, 0.3f, 0.7f);
 
-        public static bool ShowWatermelonPromotions { get; private set; } = true;
+        public static bool ShowBumiMobilePromotions { get; private set; } = true;
 
         static CoreEditor()
         {

--- a/Packages/com.bumimobile.fullserializer/CHANGELOG.md
+++ b/Packages/com.bumimobile.fullserializer/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+- (Add unreleased changes here)
+
+## [0.1.0] - 2025-12-02
+
+### Added
+
+- Initial extraction of FullSerializer into a standalone `com.bumimobile.fullserializer` UPM package.
+- Unity-ready asmdefs so other Bumi packages (`Save`, `Security`, etc.) can depend on `FullSerializer` types without pulling Visual Scripting.

--- a/Packages/com.bumimobile.fullserializer/CHANGELOG.md.meta
+++ b/Packages/com.bumimobile.fullserializer/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1d5c56f144bf4cc6820f59ad949015db
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/README.md
+++ b/Packages/com.bumimobile.fullserializer/README.md
@@ -1,0 +1,50 @@
+# Bumi Mobile FullSerializer
+
+A packaging of Jacob Weisz's FullSerializer tailored for Bumi Mobile Core. It provides deterministic JSON serialization for complex save graphs, Unity types, and cyclic references so higher-level modules (Save, Security, Monetization, etc.) can persist state without rolling their own format.
+
+## Features
+
+- **Battle-tested serializer** – `fsSerializer`, `fsData`, and the converter pipeline from FullSerializer with all Unity converters included.
+- **Unity-aware converters** – Built-in support for `Vector3`, `AnimationCurve`, `Color`, gradients, GUI styles, and other common engine types.
+- **Cycles + inheritance** – Handles object graphs with references, polymorphic fields, versioning metadata, and custom processors.
+- **Compact JSON** – `fsJsonPrinter.CompressedJson` keeps payloads small, while `PrettyJson` stays available for debugging.
+- **Bumi integration** – Distributed as a UPM package with asmdefs named `BumiMobile.FullSerializer` so other Bumi packages consume it directly.
+
+## Requirements
+
+- Unity **2021.3** or newer.
+- `com.bumimobile.core` **0.1.1+**.
+
+## Getting Started
+
+1. Add the dependency in your package or asmdef (already done for most Bumi modules).
+2. Include the namespace:
+
+```csharp
+using FullSerializer;
+```
+
+3. Serialize/deserialize your save data:
+
+```csharp
+var serializer = new fsSerializer();
+fsData data;
+serializer.TrySerialize(saveData.GetType(), saveData, out data).AssertSuccessWithoutWarnings();
+string json = fsJsonPrinter.CompressedJson(data);
+
+var parsed = fsJsonParser.Parse(json);
+object boxed = null;
+serializer.TryDeserialize(parsed, saveData.GetType(), ref boxed).AssertSuccessWithoutWarnings();
+var restored = (MySave)boxed;
+```
+
+Customize behavior through `fsConverter`, `fsObjectProcessor`, or by toggling flags in `fsGlobalConfig`.
+
+## Notes
+
+- The source is kept close to upstream FullSerializer with minimal changes (namespace alignment and asmdef packaging).
+- If you need converters for custom Unity types, place them under `FullSerializer.Internal.DirectConverters` inside your project or another Bumi package.
+
+## License
+
+See the repository root `LICENSE` for licensing terms and upstream notices.

--- a/Packages/com.bumimobile.fullserializer/README.md.meta
+++ b/Packages/com.bumimobile.fullserializer/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6e6d2cd0148a4703acfe3563a9d517b1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source.meta
+++ b/Packages/com.bumimobile.fullserializer/Source.meta
@@ -1,6 +1,7 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
-TextScriptImporter:
+guid: 3e557ef4bdc359c458fe34d1111fdc32
+folderAsset: yes
+DefaultImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Packages/com.bumimobile.fullserializer/Source/Aot.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 0b31422f318c94997a2f2f4355171037
+folderAsset: yes
+timeCreated: 1480555092
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/Editor.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e5531b3a648944071a3012cdcdba80fc
+folderAsset: yes
+timeCreated: 1480555092
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/Editor/fsAotConfigurationEditor.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/Editor/fsAotConfigurationEditor.cs
@@ -1,0 +1,250 @@
+﻿#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FullSerializer.Internal;
+using UnityEditor;
+using UnityEngine;
+
+namespace FullSerializer {
+	[InitializeOnLoad]
+	public static class PlayStateNotifier {
+		static PlayStateNotifier() {
+			EditorApplication.playModeStateChanged += ModeChanged;
+		}
+
+		private static void ModeChanged (PlayModeStateChange _) {
+			if (!EditorApplication.isPlayingOrWillChangePlaymode && EditorApplication.isPlaying) {
+				//Debug.Log("There are " + fsAotCompilationManager.AotCandidateTypes.Count + " candidate types");
+				foreach (fsAotConfiguration target in Resources.FindObjectsOfTypeAll<fsAotConfiguration>()) {
+					var seen = new HashSet<string>(target.aotTypes.Select(t => t.FullTypeName));
+					foreach (Type type in fsAotCompilationManager.AotCandidateTypes) {
+						if (seen.Contains(type.FullName) == false) {
+							target.aotTypes.Add(new fsAotConfiguration.Entry(type));
+							EditorUtility.SetDirty(target);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	[CustomEditor(typeof(fsAotConfiguration))]
+	public class fsAotConfigurationEditor : Editor {
+		[NonSerialized]
+		private List<Type> _allAotTypes;
+		private List<Type> allAotTypes {
+			get {
+				if (_allAotTypes == null)
+					_allAotTypes = FindAllAotTypes().ToList();
+				return _allAotTypes;
+			}
+		}
+
+		private string[] options = new string[] { "On", "Off", "[?]" };
+		private int GetIndexForState(fsAotConfiguration.AotState state) {
+			switch (state) {
+				case fsAotConfiguration.AotState.Enabled:
+					return 0;
+				case fsAotConfiguration.AotState.Disabled:
+					return 1;
+				case fsAotConfiguration.AotState.Default:
+					return 2;
+			}
+
+			throw new ArgumentException("state is invalid " + state);
+		}
+		private fsAotConfiguration.AotState GetStateForIndex(int index) {
+			switch (index) {
+				case 0: return fsAotConfiguration.AotState.Enabled;
+				case 1: return fsAotConfiguration.AotState.Disabled;
+				case 2: return fsAotConfiguration.AotState.Default;
+			}
+
+			throw new ArgumentException("invalid index " + index);
+		}
+
+		private IEnumerable<Type> FindAllAotTypes() {
+			foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies()) {
+				foreach (Type t in assembly.GetTypes()) {
+					bool performAot = false;
+
+					// check for [fsObject]
+					{
+						var props = t.GetCustomAttributes(typeof(fsObjectAttribute), true);
+						if (props != null && props.Length > 0) performAot = true;
+					}
+
+					// check for [fsProperty]
+					if (!performAot) {
+						foreach (PropertyInfo p in t.GetProperties()) {
+							var props = p.GetCustomAttributes(typeof(fsPropertyAttribute), true);
+							if (props.Length > 0) {
+								performAot = true;
+								break;
+							}
+						}
+					}
+
+					if (performAot)
+						yield return t;
+				}
+			}
+		}
+
+		private enum OutOfDateResult {
+			NoAot,
+			Stale,
+			Current
+		}
+		private OutOfDateResult IsOutOfDate(Type type) {
+			string converterName = fsAotCompilationManager.GetQualifiedConverterNameForType(type);
+			Type converterType = fsTypeCache.GetType(converterName);
+			if (converterType == null)
+				return OutOfDateResult.NoAot;
+
+			// TODO: We should also verify that the type is contained inside of fsConverterRegistrar as
+			//       an additional diagnostic. If it is not, then that means the type will not be used
+			//       at runtime.
+
+			object instance_ = null;
+			try {
+				instance_ = Activator.CreateInstance(converterType);
+			} catch (Exception) {}
+			if (instance_ is fsIAotConverter == false)
+				return OutOfDateResult.NoAot;
+			var instance = (fsIAotConverter)instance_;
+
+			var metatype = fsMetaType.Get(new fsConfig(), type);
+			if (fsAotCompilationManager.IsAotModelUpToDate(metatype, instance) == false)
+				return OutOfDateResult.Stale;
+
+			return OutOfDateResult.Current;
+		}
+
+		private void DrawType(fsAotConfiguration.Entry entry, Type resolvedType) {
+			var target = (fsAotConfiguration)this.target;
+
+			EditorGUILayout.BeginHorizontal();
+
+			int currentIndex = GetIndexForState(entry.State);
+			int newIndex = GUILayout.Toolbar(currentIndex, options, GUILayout.ExpandWidth(false));
+			if (currentIndex != newIndex) {
+				entry.State = GetStateForIndex(newIndex);
+				target.UpdateOrAddEntry(entry);
+				EditorUtility.SetDirty(target);
+			}
+
+			string displayName = entry.FullTypeName;
+			string tooltip = "";
+			if (resolvedType != null) {
+				displayName = resolvedType.CSharpName();
+				tooltip = resolvedType.CSharpName(true);
+			}
+			GUIContent label = new GUIContent(displayName, tooltip);
+			GUILayout.Label(label);
+
+			GUILayout.FlexibleSpace();
+
+			GUIStyle messageStyle = new GUIStyle(EditorStyles.label);
+			string message;
+			if (resolvedType != null) {
+				message = GetAotCompilationMessage(resolvedType);
+				if (string.IsNullOrEmpty(message) == false) {
+					messageStyle.normal.textColor = Color.red;
+				} else {
+					switch (IsOutOfDate(resolvedType)) {
+						case OutOfDateResult.NoAot:
+							message = "No AOT model found";
+							break;
+						case OutOfDateResult.Stale:
+							message = "Stale";
+							break;
+						case OutOfDateResult.Current:
+							message = "\u2713";
+							break;
+					}
+				}
+			} else {
+				message = "Cannot load type";
+			}
+
+			GUILayout.Label(message, messageStyle);
+
+			EditorGUILayout.EndHorizontal();
+		}
+
+		private string GetAotCompilationMessage(Type type) {
+			try {
+				fsMetaType.Get(new fsConfig(), type).EmitAotData(true);
+			} catch (Exception e) {
+				return e.Message;
+			}
+			return "";
+		}
+
+		private Vector2 _scrollPos;
+		public override void OnInspectorGUI() {
+			var target = (fsAotConfiguration)this.target;
+
+			if (GUILayout.Button("Compile")) {
+				if (Directory.Exists(target.outputDirectory) == false)
+					Directory.CreateDirectory(target.outputDirectory);
+
+				foreach (fsAotConfiguration.Entry entry in target.aotTypes) {
+					if (entry.State == fsAotConfiguration.AotState.Enabled) {
+						Type resolvedType = fsTypeCache.GetType(entry.FullTypeName);
+						if (resolvedType == null) {
+							Debug.LogError("Cannot find type " + entry.FullTypeName);
+							continue;
+						}
+
+						try {
+							string compilation = fsAotCompilationManager.RunAotCompilationForType(new fsConfig(), resolvedType);
+							string path = Path.Combine(target.outputDirectory, "AotConverter_" + resolvedType.CSharpName(true, true) + ".cs");
+							File.WriteAllText(path, compilation);
+						} catch (Exception e) {
+							Debug.LogWarning("AOT compiling " + resolvedType.CSharpName(true) + " failed: " + e.Message);
+						}
+					}
+				}
+				AssetDatabase.Refresh();
+			}
+
+			target.outputDirectory = EditorGUILayout.TextField("Output Directory", target.outputDirectory);
+
+			EditorGUILayout.BeginHorizontal();
+			GUILayout.Label("Set All");
+			int newIndex = GUILayout.Toolbar(-1, options, GUILayout.ExpandWidth(false));
+			GUILayout.FlexibleSpace();
+			EditorGUILayout.EndHorizontal();
+			if (newIndex != -1) {
+				var newState = fsAotConfiguration.AotState.Default;
+				if (newIndex == 0)
+					newState = fsAotConfiguration.AotState.Enabled;
+				else if (newIndex == 1)
+					newState = fsAotConfiguration.AotState.Disabled;
+
+				for (int i = 0; i < target.aotTypes.Count; ++i) {
+					var entry = target.aotTypes[i];
+					entry.State = newState;
+					target.aotTypes[i] = entry;
+				}
+			}
+
+
+			_scrollPos = EditorGUILayout.BeginScrollView(_scrollPos);
+			foreach (fsAotConfiguration.Entry entry in target.aotTypes) {
+				Type resolvedType = fsTypeCache.GetType(entry.FullTypeName);
+				EditorGUI.BeginDisabledGroup(resolvedType == null || string.IsNullOrEmpty(GetAotCompilationMessage(resolvedType)) == false);
+				DrawType(entry, resolvedType);
+				EditorGUI.EndDisabledGroup();
+			}
+			EditorGUILayout.EndScrollView();
+		}
+
+	}
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/Editor/fsAotConfigurationEditor.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/Editor/fsAotConfigurationEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ccf7caf222d44eed8cf021b6738e8c2

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotCompilationManager.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotCompilationManager.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FullSerializer.Internal;
+
+namespace FullSerializer {
+    /// <summary>
+    /// The AOT compilation manager
+    /// </summary>
+    public class fsAotCompilationManager {
+        private static bool HasMember(fsAotVersionInfo versionInfo, fsAotVersionInfo.Member member) {
+            foreach (fsAotVersionInfo.Member foundMember in versionInfo.Members) {
+                if (foundMember == member)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if the given aotModel can be used. Returns false if it needs to
+        /// be recompiled.
+        /// </summary>
+        public static bool IsAotModelUpToDate(fsMetaType currentModel, fsIAotConverter aotModel) {
+            if (currentModel.IsDefaultConstructorPublic != aotModel.VersionInfo.IsConstructorPublic)
+                return false;
+
+            if (currentModel.Properties.Length != aotModel.VersionInfo.Members.Length)
+                return false;
+
+            foreach (fsMetaProperty property in currentModel.Properties) {
+                if (HasMember(aotModel.VersionInfo, new fsAotVersionInfo.Member(property)) == false) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Ahead of time compilations that are available. The type maps to the
+        /// object type the generated converter will serialize/deserialize, and
+        /// the string is the text content for a converter that will do the
+        /// serialization.
+        /// <para/>
+        /// The generated serializer is completely independent and you don't need
+        /// to do anything. Simply add the file to your project and it'll get
+        /// used instead of the reflection based one.
+        /// </summary>
+        public static string RunAotCompilationForType(fsConfig config, Type type) {
+            fsMetaType metatype = fsMetaType.Get(config, type);
+            metatype.EmitAotData(/*throwException:*/ true);
+            return GenerateDirectConverterForTypeInCSharp(type, metatype.Properties, metatype.IsDefaultConstructorPublic);
+        }
+
+        /// <summary>
+        /// A set of types which should be considered for AOT compilation. This
+        /// set is populated by the reflected converter.
+        /// </summary>
+        public static HashSet<Type> AotCandidateTypes = new HashSet<Type>();
+
+        private static string EmitVersionInfo(string prefix, Type type, fsMetaProperty[] members, bool isConstructorPublic) {
+            var sb = new StringBuilder();
+
+            sb.AppendLine("new fsAotVersionInfo {");
+            sb.AppendLine(prefix + "    IsConstructorPublic = " + (isConstructorPublic ? "true" : "false") + ",");
+            sb.AppendLine(prefix + "    Members = new fsAotVersionInfo.Member[] {");
+            foreach (fsMetaProperty member in members) {
+                sb.AppendLine(prefix + "        new fsAotVersionInfo.Member {");
+                sb.AppendLine(prefix + "            MemberName = \"" + member.MemberName + "\",");
+                sb.AppendLine(prefix + "            JsonName = \"" + member.JsonName + "\",");
+                sb.AppendLine(prefix + "            StorageType = \"" + member.StorageType.CSharpName(true) + "\",");
+                if (member.OverrideConverterType != null)
+                    sb.AppendLine(prefix + "            OverrideConverterType = \"" + member.OverrideConverterType.CSharpName(true) + "\",");
+                sb.AppendLine(prefix + "        },");
+            }
+            sb.AppendLine(prefix + "    }");
+            sb.Append(prefix + "}");
+
+            return sb.ToString();
+        }
+
+        private static string GetConverterString(fsMetaProperty member) {
+            if (member.OverrideConverterType == null)
+                return "null";
+
+            return string.Format("typeof({0})",
+                                 member.OverrideConverterType.CSharpName(/*includeNamespace:*/ true));
+        }
+
+        public static string GetQualifiedConverterNameForType(Type type) {
+            return "FullSerializer.Speedup." + type.CSharpName(true, true) + "_DirectConverter";
+        }
+
+        /// <summary>
+        /// AOT compiles the object (in C#).
+        /// </summary>
+        private static string GenerateDirectConverterForTypeInCSharp(Type type, fsMetaProperty[] members, bool isConstructorPublic) {
+            var sb = new StringBuilder();
+            string typeName = type.CSharpName(/*includeNamespace:*/ true);
+            string typeNameSafeDecl = type.CSharpName(true, true);
+
+            sb.AppendLine("using System;");
+            sb.AppendLine("using System.Collections.Generic;");
+            sb.AppendLine();
+            sb.AppendLine("namespace FullSerializer {");
+            sb.AppendLine("    partial class fsConverterRegistrar {");
+            sb.AppendLine("        public static Speedup." + typeNameSafeDecl + "_DirectConverter " + "Register_" + typeNameSafeDecl + ";");
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            sb.AppendLine();
+            sb.AppendLine("namespace FullSerializer.Speedup {");
+            sb.AppendLine("    public class " + typeNameSafeDecl + "_DirectConverter : fsDirectConverter<" + typeName + ">, fsIAotConverter {");
+            sb.AppendLine("        private fsAotVersionInfo _versionInfo = " + EmitVersionInfo("        ", type, members, isConstructorPublic) + ";");
+            sb.AppendLine("        fsAotVersionInfo fsIAotConverter.VersionInfo { get { return _versionInfo; } }");
+            sb.AppendLine();
+            sb.AppendLine("        protected override fsResult DoSerialize(" + typeName + " model, Dictionary<string, fsData> serialized) {");
+            sb.AppendLine("            var result = fsResult.Success;");
+            sb.AppendLine();
+            foreach (var member in members) {
+                sb.AppendLine("            result += SerializeMember(serialized, " + GetConverterString(member) + ", \"" + member.JsonName + "\", model." + member.MemberName + ");");
+            }
+            sb.AppendLine();
+            sb.AppendLine("            return result;");
+            sb.AppendLine("        }");
+            sb.AppendLine();
+            sb.AppendLine("        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref " + typeName + " model) {");
+            sb.AppendLine("            var result = fsResult.Success;");
+            sb.AppendLine();
+            for (int i = 0; i < members.Length; ++i) {
+                var member = members[i];
+                sb.AppendLine("            var t" + i + " = model." + member.MemberName + ";");
+                sb.AppendLine("            result += DeserializeMember(data, " + GetConverterString(member) + ", \"" + member.JsonName + "\", out t" + i + ");");
+                sb.AppendLine("            model." + member.MemberName + " = t" + i + ";");
+                sb.AppendLine();
+            }
+            sb.AppendLine("            return result;");
+            sb.AppendLine("        }");
+            sb.AppendLine();
+            sb.AppendLine("        public override object CreateInstance(fsData data, Type storageType) {");
+            if (isConstructorPublic) {
+                sb.AppendLine("            return new " + typeName + "();");
+            }
+            else {
+                sb.AppendLine("            return Activator.CreateInstance(typeof(" + typeName + "), /*nonPublic:*/true);");
+            }
+            sb.AppendLine("        }");
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotCompilationManager.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotCompilationManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e2bc880fbc9d241329a22ff808ff7571
+timeCreated: 1480555092
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotConfiguration.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotConfiguration.cs
@@ -1,0 +1,56 @@
+#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    [CreateAssetMenu(menuName = "Full Serializer AOT Configuration")]
+    public class fsAotConfiguration : ScriptableObject {
+        public enum AotState {
+            Default, Enabled, Disabled
+        }
+
+        [Serializable]
+        public struct Entry {
+            public AotState State;
+            public string FullTypeName;
+
+            public Entry(Type type) {
+                FullTypeName = type.FullName;
+                State = AotState.Default;
+            }
+
+            public Entry(Type type, AotState state) {
+                FullTypeName = type.FullName;
+                State = state;
+            }
+        }
+		public List<Entry> aotTypes = new List<Entry>();
+        public string outputDirectory = "Assets/AotModels";
+
+        public bool TryFindEntry(Type type, out Entry result) {
+            string searchFor = type.FullName;
+            foreach (Entry entry in aotTypes) {
+                if (entry.FullTypeName == searchFor) {
+                    result = entry;
+                    return true;
+                }
+            }
+
+            result = default(Entry);
+            return false;
+        }
+
+        public void UpdateOrAddEntry(Entry entry) {
+            for (int i = 0; i < aotTypes.Count; ++i) {
+                if (aotTypes[i].FullTypeName == entry.FullTypeName) {
+                    aotTypes[i] = entry;
+                    return;
+                }
+            }
+
+            aotTypes.Add(entry);
+        }
+	}
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotConfiguration.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotConfiguration.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e8ec4e71611a049c195a9e7464f46334
+timeCreated: 1480555092
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotVersionInfo.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotVersionInfo.cs
@@ -1,0 +1,52 @@
+using FullSerializer.Internal;
+
+namespace FullSerializer {
+    /// <summary>
+    /// Version information stored on an AOT model. This is used to determine
+    /// if the AOT model is up to date.
+    /// </summary>
+    public struct fsAotVersionInfo {
+        public struct Member {
+            public string MemberName;
+            public string JsonName;
+            public string StorageType;
+            public string OverrideConverterType;
+
+            public Member(fsMetaProperty property) {
+                MemberName = property.MemberName;
+                JsonName = property.JsonName;
+                StorageType = property.StorageType.CSharpName(true);
+                OverrideConverterType = null;
+                if (property.OverrideConverterType != null)
+                    OverrideConverterType = property.OverrideConverterType.CSharpName();
+            }
+
+            public override bool Equals(object obj) {
+                if (obj is Member == false)
+                    return false;
+                return this == ((Member)obj);
+            }
+            public override int GetHashCode() {
+                return
+                    MemberName.GetHashCode() +
+                    (17 * JsonName.GetHashCode()) +
+                    (17 * StorageType.GetHashCode()) +
+                    (string.IsNullOrEmpty(OverrideConverterType) ? 0 : 17 * OverrideConverterType.GetHashCode());
+            }
+            public static bool operator ==(Member a, Member b) {
+                return a.MemberName == b.MemberName &&
+                       a.JsonName == b.JsonName &&
+                       a.StorageType == b.StorageType &&
+                       a.OverrideConverterType == b.OverrideConverterType;
+            }
+            public static bool operator !=(Member a, Member b) {
+                return !(a == b);
+            }
+        }
+
+        public bool IsConstructorPublic;
+        public Member[] Members;
+    }
+
+
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotVersionInfo.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/fsAotVersionInfo.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 32c07201cc4594e4ba2d95970c54c705
+timeCreated: 1480555092
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/fsIAotConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/fsIAotConverter.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace FullSerializer {
+    /// <summary>
+    /// Interface that AOT generated converters extend. Used to check to see if
+    /// the AOT converter is up to date.
+    /// </summary>
+    public interface fsIAotConverter {
+        Type ModelType { get; }
+        fsAotVersionInfo VersionInfo { get; }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Aot/fsIAotConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Aot/fsIAotConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b4aeef439e364442ea22128e6bc172be
+timeCreated: 1480555092
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/BumiMobile.FullSerializer.asmdef
+++ b/Packages/com.bumimobile.fullserializer/Source/BumiMobile.FullSerializer.asmdef
@@ -1,0 +1,12 @@
+{
+  "name": "BumiMobile.FullSerializer",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "noEngineReferences": false
+}

--- a/Packages/com.bumimobile.fullserializer/Source/BumiMobile.FullSerializer.asmdef.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/BumiMobile.FullSerializer.asmdef.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
-TextScriptImporter:
+guid: 6e17235193adacc439be55d046b96864
+AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e294e082a4f8d4a43ae3e07ab9c0d52d
+folderAsset: yes
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ec452919b13057d47ba7b28425969b96
+folderAsset: yes
+timeCreated: 1427576137
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/AnimationCurve_DirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/AnimationCurve_DirectConverter.cs
@@ -1,0 +1,47 @@
+#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        public static Internal.DirectConverters.AnimationCurve_DirectConverter Register_AnimationCurve_DirectConverter;
+    }
+}
+
+namespace FullSerializer.Internal.DirectConverters {
+    public class AnimationCurve_DirectConverter : fsDirectConverter<AnimationCurve> {
+        protected override fsResult DoSerialize(AnimationCurve model, Dictionary<string, fsData> serialized) {
+            var result = fsResult.Success;
+
+            result += SerializeMember(serialized, null, "keys", model.keys);
+            result += SerializeMember(serialized, null, "preWrapMode", model.preWrapMode);
+            result += SerializeMember(serialized, null, "postWrapMode", model.postWrapMode);
+
+            return result;
+        }
+
+        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref AnimationCurve model) {
+            var result = fsResult.Success;
+
+            var t0 = model.keys;
+            result += DeserializeMember(data, null, "keys", out t0);
+            model.keys = t0;
+
+            var t1 = model.preWrapMode;
+            result += DeserializeMember(data, null, "preWrapMode", out t1);
+            model.preWrapMode = t1;
+
+            var t2 = model.postWrapMode;
+            result += DeserializeMember(data, null, "postWrapMode", out t2);
+            model.postWrapMode = t2;
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new AnimationCurve();
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/AnimationCurve_DirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/AnimationCurve_DirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: de4871d163dc05c4e879ab3bd2d1b0a9
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Bounds_DirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Bounds_DirectConverter.cs
@@ -1,0 +1,42 @@
+#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        public static Internal.DirectConverters.Bounds_DirectConverter Register_Bounds_DirectConverter;
+    }
+}
+
+namespace FullSerializer.Internal.DirectConverters {
+    public class Bounds_DirectConverter : fsDirectConverter<Bounds> {
+        protected override fsResult DoSerialize(Bounds model, Dictionary<string, fsData> serialized) {
+            var result = fsResult.Success;
+
+            result += SerializeMember(serialized, null, "center", model.center);
+            result += SerializeMember(serialized, null, "size", model.size);
+
+            return result;
+        }
+
+        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref Bounds model) {
+            var result = fsResult.Success;
+
+            var t0 = model.center;
+            result += DeserializeMember(data, null, "center", out t0);
+            model.center = t0;
+
+            var t1 = model.size;
+            result += DeserializeMember(data, null, "size", out t1);
+            model.size = t1;
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new Bounds();
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Bounds_DirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Bounds_DirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3fe9630466a01c34fba9de74b67e17f6
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/GUIStyleState_DirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/GUIStyleState_DirectConverter.cs
@@ -1,0 +1,42 @@
+﻿#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        public static Internal.DirectConverters.GUIStyleState_DirectConverter Register_GUIStyleState_DirectConverter;
+    }
+}
+
+namespace FullSerializer.Internal.DirectConverters {
+    public class GUIStyleState_DirectConverter : fsDirectConverter<GUIStyleState> {
+        protected override fsResult DoSerialize(GUIStyleState model, Dictionary<string, fsData> serialized) {
+            var result = fsResult.Success;
+
+            result += SerializeMember(serialized, null, "background", model.background);
+            result += SerializeMember(serialized, null, "textColor", model.textColor);
+
+            return result;
+        }
+
+        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref GUIStyleState model) {
+            var result = fsResult.Success;
+
+            var t0 = model.background;
+            result += DeserializeMember(data, null, "background", out t0);
+            model.background = t0;
+
+            var t2 = model.textColor;
+            result += DeserializeMember(data, null, "textColor", out t2);
+            model.textColor = t2;
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new GUIStyleState();
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/GUIStyleState_DirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/GUIStyleState_DirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 67b4783438fecdb4399aa4737e11776b
+timeCreated: 1455511482
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/GUIStyle_DirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/GUIStyle_DirectConverter.cs
@@ -1,0 +1,162 @@
+﻿#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        public static Internal.DirectConverters.GUIStyle_DirectConverter Register_GUIStyle_DirectConverter;
+    }
+}
+
+namespace FullSerializer.Internal.DirectConverters {
+    public class GUIStyle_DirectConverter : fsDirectConverter<GUIStyle> {
+        protected override fsResult DoSerialize(GUIStyle model, Dictionary<string, fsData> serialized) {
+            var result = fsResult.Success;
+
+            result += SerializeMember(serialized, null, "active", model.active);
+            result += SerializeMember(serialized, null, "alignment", model.alignment);
+            result += SerializeMember(serialized, null, "border", model.border);
+            result += SerializeMember(serialized, null, "clipping", model.clipping);
+            result += SerializeMember(serialized, null, "contentOffset", model.contentOffset);
+            result += SerializeMember(serialized, null, "fixedHeight", model.fixedHeight);
+            result += SerializeMember(serialized, null, "fixedWidth", model.fixedWidth);
+            result += SerializeMember(serialized, null, "focused", model.focused);
+            result += SerializeMember(serialized, null, "font", model.font);
+            result += SerializeMember(serialized, null, "fontSize", model.fontSize);
+            result += SerializeMember(serialized, null, "fontStyle", model.fontStyle);
+            result += SerializeMember(serialized, null, "hover", model.hover);
+            result += SerializeMember(serialized, null, "imagePosition", model.imagePosition);
+            result += SerializeMember(serialized, null, "margin", model.margin);
+            result += SerializeMember(serialized, null, "name", model.name);
+            result += SerializeMember(serialized, null, "normal", model.normal);
+            result += SerializeMember(serialized, null, "onActive", model.onActive);
+            result += SerializeMember(serialized, null, "onFocused", model.onFocused);
+            result += SerializeMember(serialized, null, "onHover", model.onHover);
+            result += SerializeMember(serialized, null, "onNormal", model.onNormal);
+            result += SerializeMember(serialized, null, "overflow", model.overflow);
+            result += SerializeMember(serialized, null, "padding", model.padding);
+            result += SerializeMember(serialized, null, "richText", model.richText);
+            result += SerializeMember(serialized, null, "stretchHeight", model.stretchHeight);
+            result += SerializeMember(serialized, null, "stretchWidth", model.stretchWidth);
+            result += SerializeMember(serialized, null, "wordWrap", model.wordWrap);
+
+            return result;
+        }
+
+        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref GUIStyle model) {
+            var result = fsResult.Success;
+
+            var t0 = model.active;
+            result += DeserializeMember(data, null, "active", out t0);
+            model.active = t0;
+
+            var t2 = model.alignment;
+            result += DeserializeMember(data, null, "alignment", out t2);
+            model.alignment = t2;
+
+            var t3 = model.border;
+            result += DeserializeMember(data, null, "border", out t3);
+            model.border = t3;
+
+            var t4 = model.clipping;
+            result += DeserializeMember(data, null, "clipping", out t4);
+            model.clipping = t4;
+
+            var t5 = model.contentOffset;
+            result += DeserializeMember(data, null, "contentOffset", out t5);
+            model.contentOffset = t5;
+
+            var t6 = model.fixedHeight;
+            result += DeserializeMember(data, null, "fixedHeight", out t6);
+            model.fixedHeight = t6;
+
+            var t7 = model.fixedWidth;
+            result += DeserializeMember(data, null, "fixedWidth", out t7);
+            model.fixedWidth = t7;
+
+            var t8 = model.focused;
+            result += DeserializeMember(data, null, "focused", out t8);
+            model.focused = t8;
+
+            var t9 = model.font;
+            result += DeserializeMember(data, null, "font", out t9);
+            model.font = t9;
+
+            var t10 = model.fontSize;
+            result += DeserializeMember(data, null, "fontSize", out t10);
+            model.fontSize = t10;
+
+            var t11 = model.fontStyle;
+            result += DeserializeMember(data, null, "fontStyle", out t11);
+            model.fontStyle = t11;
+
+            var t12 = model.hover;
+            result += DeserializeMember(data, null, "hover", out t12);
+            model.hover = t12;
+
+            var t13 = model.imagePosition;
+            result += DeserializeMember(data, null, "imagePosition", out t13);
+            model.imagePosition = t13;
+
+            var t16 = model.margin;
+            result += DeserializeMember(data, null, "margin", out t16);
+            model.margin = t16;
+
+            var t17 = model.name;
+            result += DeserializeMember(data, null, "name", out t17);
+            model.name = t17;
+
+            var t18 = model.normal;
+            result += DeserializeMember(data, null, "normal", out t18);
+            model.normal = t18;
+
+            var t19 = model.onActive;
+            result += DeserializeMember(data, null, "onActive", out t19);
+            model.onActive = t19;
+
+            var t20 = model.onFocused;
+            result += DeserializeMember(data, null, "onFocused", out t20);
+            model.onFocused = t20;
+
+            var t21 = model.onHover;
+            result += DeserializeMember(data, null, "onHover", out t21);
+            model.onHover = t21;
+
+            var t22 = model.onNormal;
+            result += DeserializeMember(data, null, "onNormal", out t22);
+            model.onNormal = t22;
+
+            var t23 = model.overflow;
+            result += DeserializeMember(data, null, "overflow", out t23);
+            model.overflow = t23;
+
+            var t24 = model.padding;
+            result += DeserializeMember(data, null, "padding", out t24);
+            model.padding = t24;
+
+            var t25 = model.richText;
+            result += DeserializeMember(data, null, "richText", out t25);
+            model.richText = t25;
+
+            var t26 = model.stretchHeight;
+            result += DeserializeMember(data, null, "stretchHeight", out t26);
+            model.stretchHeight = t26;
+
+            var t27 = model.stretchWidth;
+            result += DeserializeMember(data, null, "stretchWidth", out t27);
+            model.stretchWidth = t27;
+
+            var t28 = model.wordWrap;
+            result += DeserializeMember(data, null, "wordWrap", out t28);
+            model.wordWrap = t28;
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new GUIStyle();
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/GUIStyle_DirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/GUIStyle_DirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 08c93192f19b1a74a91771d664d38f0b
+timeCreated: 1455511482
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Gradient_DirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Gradient_DirectConverter.cs
@@ -1,0 +1,42 @@
+#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        public static Internal.DirectConverters.Gradient_DirectConverter Register_Gradient_DirectConverter;
+    }
+}
+
+namespace FullSerializer.Internal.DirectConverters {
+    public class Gradient_DirectConverter : fsDirectConverter<Gradient> {
+        protected override fsResult DoSerialize(Gradient model, Dictionary<string, fsData> serialized) {
+            var result = fsResult.Success;
+
+            result += SerializeMember(serialized, null, "alphaKeys", model.alphaKeys);
+            result += SerializeMember(serialized, null, "colorKeys", model.colorKeys);
+
+            return result;
+        }
+
+        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref Gradient model) {
+            var result = fsResult.Success;
+
+            var t0 = model.alphaKeys;
+            result += DeserializeMember(data, null, "alphaKeys", out t0);
+            model.alphaKeys = t0;
+
+            var t1 = model.colorKeys;
+            result += DeserializeMember(data, null, "colorKeys", out t1);
+            model.colorKeys = t1;
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new Gradient();
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Gradient_DirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Gradient_DirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 064742214cced30408a50448cc56cf32
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Keyframe_DirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Keyframe_DirectConverter.cs
@@ -1,0 +1,67 @@
+#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        public static Internal.DirectConverters.Keyframe_DirectConverter Register_Keyframe_DirectConverter;
+    }
+}
+
+namespace FullSerializer.Internal.DirectConverters {
+    public class Keyframe_DirectConverter : fsDirectConverter<Keyframe> {
+        protected override fsResult DoSerialize(Keyframe model, Dictionary<string, fsData> serialized) {
+            var result = fsResult.Success;
+
+            result += SerializeMember(serialized, null, "time", model.time);
+            result += SerializeMember(serialized, null, "value", model.value);
+            result += SerializeMember(serialized, null, "inTangent", model.inTangent);
+            result += SerializeMember(serialized, null, "outTangent", model.outTangent);
+            result += SerializeMember(serialized, null, "outWeight", model.outWeight);
+            result += SerializeMember(serialized, null, "inWeight", model.inWeight);
+            result += SerializeMember(serialized, null, "weightedMode", model.weightedMode);
+
+            return result;
+        }
+
+        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref Keyframe model) {
+            var result = fsResult.Success;
+
+            var t0 = model.time;
+            result += DeserializeMember(data, null, "time", out t0);
+            model.time = t0;
+
+            var t1 = model.value;
+            result += DeserializeMember(data, null, "value", out t1);
+            model.value = t1;
+
+            var t2 = model.inTangent;
+            result += DeserializeMember(data, null, "inTangent", out t2);
+            model.inTangent = t2;
+
+            var t3 = model.outTangent;
+            result += DeserializeMember(data, null, "outTangent", out t3);
+            model.outTangent = t3;
+
+            var t4 = model.outWeight;
+            result += DeserializeMember(data, null, "outWeight", out t4);
+            model.outWeight = t4;
+
+            var t5 = model.inWeight;
+            result += DeserializeMember(data, null, "inWeight", out t5);
+            model.inWeight = t5;
+
+            var t6 = model.weightedMode;
+            result += DeserializeMember(data, null, "weightedMode", out t6);
+            model.weightedMode = t6;
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new Keyframe();
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Keyframe_DirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Keyframe_DirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 685e0c3230dc4c1469af759c0cadadb0
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/LayerMask_DirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/LayerMask_DirectConverter.cs
@@ -1,0 +1,37 @@
+#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        public static Internal.DirectConverters.LayerMask_DirectConverter Register_LayerMask_DirectConverter;
+    }
+}
+
+namespace FullSerializer.Internal.DirectConverters {
+    public class LayerMask_DirectConverter : fsDirectConverter<LayerMask> {
+        protected override fsResult DoSerialize(LayerMask model, Dictionary<string, fsData> serialized) {
+            var result = fsResult.Success;
+
+            result += SerializeMember(serialized, null, "value", model.value);
+
+            return result;
+        }
+
+        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref LayerMask model) {
+            var result = fsResult.Success;
+
+            var t0 = model.value;
+            result += DeserializeMember(data, null, "value", out t0);
+            model.value = t0;
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new LayerMask();
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/LayerMask_DirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/LayerMask_DirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3a480ab5fab4f3041a1dc7468d23ab7c
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/RectOffset_DirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/RectOffset_DirectConverter.cs
@@ -1,0 +1,52 @@
+﻿#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        public static Internal.DirectConverters.RectOffset_DirectConverter Register_RectOffset_DirectConverter;
+    }
+}
+
+namespace FullSerializer.Internal.DirectConverters {
+    public class RectOffset_DirectConverter : fsDirectConverter<RectOffset> {
+        protected override fsResult DoSerialize(RectOffset model, Dictionary<string, fsData> serialized) {
+            var result = fsResult.Success;
+
+            result += SerializeMember(serialized, null, "bottom", model.bottom);
+            result += SerializeMember(serialized, null, "left", model.left);
+            result += SerializeMember(serialized, null, "right", model.right);
+            result += SerializeMember(serialized, null, "top", model.top);
+
+            return result;
+        }
+
+        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref RectOffset model) {
+            var result = fsResult.Success;
+
+            var t0 = model.bottom;
+            result += DeserializeMember(data, null, "bottom", out t0);
+            model.bottom = t0;
+
+            var t2 = model.left;
+            result += DeserializeMember(data, null, "left", out t2);
+            model.left = t2;
+
+            var t3 = model.right;
+            result += DeserializeMember(data, null, "right", out t3);
+            model.right = t3;
+
+            var t4 = model.top;
+            result += DeserializeMember(data, null, "top", out t4);
+            model.top = t4;
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new RectOffset();
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/RectOffset_DirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/RectOffset_DirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8b6ebe5ce2ccdb4439953bd49e36ac3a
+timeCreated: 1455511482
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Rect_DirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Rect_DirectConverter.cs
@@ -1,0 +1,52 @@
+#if !NO_UNITY
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        public static Internal.DirectConverters.Rect_DirectConverter Register_Rect_DirectConverter;
+    }
+}
+
+namespace FullSerializer.Internal.DirectConverters {
+    public class Rect_DirectConverter : fsDirectConverter<Rect> {
+        protected override fsResult DoSerialize(Rect model, Dictionary<string, fsData> serialized) {
+            var result = fsResult.Success;
+
+            result += SerializeMember(serialized, null, "xMin", model.xMin);
+            result += SerializeMember(serialized, null, "yMin", model.yMin);
+            result += SerializeMember(serialized, null, "xMax", model.xMax);
+            result += SerializeMember(serialized, null, "yMax", model.yMax);
+
+            return result;
+        }
+
+        protected override fsResult DoDeserialize(Dictionary<string, fsData> data, ref Rect model) {
+            var result = fsResult.Success;
+
+            var t0 = model.xMin;
+            result += DeserializeMember(data, null, "xMin", out t0);
+            model.xMin = t0;
+
+            var t1 = model.yMin;
+            result += DeserializeMember(data, null, "yMin", out t1);
+            model.yMin = t1;
+
+            var t2 = model.xMax;
+            result += DeserializeMember(data, null, "xMax", out t2);
+            model.xMax = t2;
+
+            var t3 = model.yMax;
+            result += DeserializeMember(data, null, "yMax", out t3);
+            model.yMax = t3;
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new Rect();
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Rect_DirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/Rect_DirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 06db9349c97ef41438333fe8ef2c2f70
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/UnityEvent_Converter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/UnityEvent_Converter.cs
@@ -1,0 +1,48 @@
+#if !NO_UNITY && UNITY_5_3_OR_NEWER
+using System;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace FullSerializer {
+    partial class fsConverterRegistrar {
+        // Disable the converter for the time being. Unity's JsonUtility API
+        // cannot be called from within a C# ISerializationCallbackReceiver
+        // callback.
+
+        // public static Internal.Converters.UnityEvent_Converter
+        // Register_UnityEvent_Converter;
+    }
+}
+
+namespace FullSerializer.Internal.Converters {
+    // The standard FS reflection converter has started causing Unity to crash
+    // when processing UnityEvent. We can send the serialization through
+    // JsonUtility which appears to work correctly instead.
+    //
+    // We have to support legacy serialization formats so importing works as
+    // expected.
+    public class UnityEvent_Converter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return typeof(UnityEvent).Resolve().IsAssignableFrom(type.Resolve()) && type.IsGenericType() == false;
+        }
+
+        public override bool RequestCycleSupport(Type storageType) {
+            return false;
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            Type objectType = (Type)instance;
+
+            fsResult result = fsResult.Success;
+            instance = JsonUtility.FromJson(fsJsonPrinter.CompressedJson(data), objectType);
+            return result;
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            fsResult result = fsResult.Success;
+            serialized = fsJsonParser.Parse(JsonUtility.ToJson(instance));
+            return result;
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/UnityEvent_Converter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/Unity/UnityEvent_Converter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9a695d8e2a84646fbb7db60dc4fbbbd4
+timeCreated: 1469719791
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsArrayConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsArrayConverter.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections;
+
+namespace FullSerializer.Internal {
+    public class fsArrayConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return type.IsArray;
+        }
+
+        public override bool RequestCycleSupport(Type storageType) {
+            return false;
+        }
+
+        public override bool RequestInheritanceSupport(Type storageType) {
+            return false;
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            // note: IList[index] is **significantly** faster than Array.Get, so
+            //       make sure we use that instead.
+
+            IList arr = (Array)instance;
+            Type elementType = storageType.GetElementType();
+
+            var result = fsResult.Success;
+
+            serialized = fsData.CreateList(arr.Count);
+            var serializedList = serialized.AsList;
+
+            for (int i = 0; i < arr.Count; ++i) {
+                object item = arr[i];
+
+                fsData serializedItem;
+
+                var itemResult = Serializer.TrySerialize(elementType, item, out serializedItem);
+                result.AddMessages(itemResult);
+                if (itemResult.Failed) continue;
+
+                serializedList.Add(serializedItem);
+            }
+
+            return result;
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            var result = fsResult.Success;
+
+            // Verify that we actually have an List
+            if ((result += CheckType(data, fsDataType.Array)).Failed) {
+                return result;
+            }
+
+            Type elementType = storageType.GetElementType();
+
+            var serializedList = data.AsList;
+            var list = new ArrayList(serializedList.Count);
+            int existingCount = list.Count;
+
+            for (int i = 0; i < serializedList.Count; ++i) {
+                var serializedItem = serializedList[i];
+                object deserialized = null;
+                if (i < existingCount) deserialized = list[i];
+
+                var itemResult = Serializer.TryDeserialize(serializedItem, elementType, ref deserialized);
+                result.AddMessages(itemResult);
+                if (itemResult.Failed) continue;
+
+                if (i < existingCount) list[i] = deserialized;
+                else list.Add(deserialized);
+            }
+
+            instance = list.ToArray(elementType);
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return fsMetaType.Get(Serializer.Config, storageType).CreateInstance();
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsArrayConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsArrayConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a8c61b81ee2d4ce41988db051d54e60a
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsDateConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsDateConverter.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Globalization;
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// Supports serialization for DateTime, DateTimeOffset, and TimeSpan.
+    /// </summary>
+    public class fsDateConverter : fsConverter {
+        // The format strings that we use when serializing DateTime and
+        // DateTimeOffset types.
+        private const string DefaultDateTimeFormatString = @"o";
+        private const string DateTimeOffsetFormatString = @"o";
+
+        private string DateTimeFormatString {
+            get {
+                return Serializer.Config.CustomDateTimeFormatString ?? DefaultDateTimeFormatString;
+            }
+        }
+
+        public override bool CanProcess(Type type) {
+            return
+                type == typeof(DateTime) ||
+                type == typeof(DateTimeOffset) ||
+                type == typeof(TimeSpan);
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            if (instance is DateTime) {
+                var dateTime = (DateTime)instance;
+                serialized = new fsData(dateTime.ToString(DateTimeFormatString));
+                return fsResult.Success;
+            }
+
+            if (instance is DateTimeOffset) {
+                var dateTimeOffset = (DateTimeOffset)instance;
+                serialized = new fsData(dateTimeOffset.ToString(DateTimeOffsetFormatString));
+                return fsResult.Success;
+            }
+
+            if (instance is TimeSpan) {
+                var timeSpan = (TimeSpan)instance;
+                serialized = new fsData(timeSpan.ToString());
+                return fsResult.Success;
+            }
+
+            throw new InvalidOperationException("FullSerializer Internal Error -- Unexpected serialization type");
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            if (data.IsString == false) {
+                return fsResult.Fail("Date deserialization requires a string, not " + data.Type);
+            }
+
+            if (storageType == typeof(DateTime)) {
+                DateTime result;
+                if (DateTime.TryParse(data.AsString, null, DateTimeStyles.RoundtripKind, out result)) {
+                    instance = result;
+                    return fsResult.Success;
+                }
+
+                // DateTime.TryParse can fail for some valid DateTime instances.
+                // Try to use Convert.ToDateTime.
+                if (fsGlobalConfig.AllowInternalExceptions) {
+                    try {
+                        instance = Convert.ToDateTime(data.AsString);
+                        return fsResult.Success;
+                    }
+                    catch (Exception e) {
+                        return fsResult.Fail("Unable to parse " + data.AsString + " into a DateTime; got exception " + e);
+                    }
+                }
+
+                return fsResult.Fail("Unable to parse " + data.AsString + " into a DateTime");
+            }
+
+            if (storageType == typeof(DateTimeOffset)) {
+                DateTimeOffset result;
+                if (DateTimeOffset.TryParse(data.AsString, null, DateTimeStyles.RoundtripKind, out result)) {
+                    instance = result;
+                    return fsResult.Success;
+                }
+
+                return fsResult.Fail("Unable to parse " + data.AsString + " into a DateTimeOffset");
+            }
+
+            if (storageType == typeof(TimeSpan)) {
+                TimeSpan result;
+                if (TimeSpan.TryParse(data.AsString, out result)) {
+                    instance = result;
+                    return fsResult.Success;
+                }
+
+                return fsResult.Fail("Unable to parse " + data.AsString + " into a TimeSpan");
+            }
+
+            throw new InvalidOperationException("FullSerializer Internal Error -- Unexpected deserialization type");
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsDateConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsDateConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 892fb7e848a12c74681de14331c8a072
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsDictionaryConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsDictionaryConverter.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace FullSerializer.Internal {
+    // While the generic IEnumerable converter can handle dictionaries, we
+    // process them separately here because we support a few more advanced
+    // use-cases with dictionaries, such as inline strings. Further, dictionary
+    // processing in general is a bit more advanced because a few of the
+    // collection implementations are buggy.
+    public class fsDictionaryConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return typeof(IDictionary).IsAssignableFrom(type);
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return fsMetaType.Get(Serializer.Config, storageType).CreateInstance();
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance_, Type storageType) {
+            var instance = (IDictionary)instance_;
+            var result = fsResult.Success;
+
+            Type keyStorageType, valueStorageType;
+            GetKeyValueTypes(instance.GetType(), out keyStorageType, out valueStorageType);
+
+            if (data.IsList) {
+                var list = data.AsList;
+                for (int i = 0; i < list.Count; ++i) {
+                    var item = list[i];
+
+                    fsData keyData, valueData;
+                    if ((result += CheckType(item, fsDataType.Object)).Failed) return result;
+                    if ((result += CheckKey(item, "Key", out keyData)).Failed) return result;
+                    if ((result += CheckKey(item, "Value", out valueData)).Failed) return result;
+
+                    object keyInstance = null, valueInstance = null;
+                    if ((result += Serializer.TryDeserialize(keyData, keyStorageType, ref keyInstance)).Failed) return result;
+                    if ((result += Serializer.TryDeserialize(valueData, valueStorageType, ref valueInstance)).Failed) return result;
+
+                    AddItemToDictionary(instance, keyInstance, valueInstance);
+                }
+            }
+            else if (data.IsDictionary) {
+                foreach (var entry in data.AsDictionary) {
+                    if (fsSerializer.IsReservedKeyword(entry.Key)) continue;
+
+                    fsData keyData = new fsData(entry.Key), valueData = entry.Value;
+                    object keyInstance = null, valueInstance = null;
+
+                    if ((result += Serializer.TryDeserialize(keyData, keyStorageType, ref keyInstance)).Failed) return result;
+                    if ((result += Serializer.TryDeserialize(valueData, valueStorageType, ref valueInstance)).Failed) return result;
+
+                    AddItemToDictionary(instance, keyInstance, valueInstance);
+                }
+            }
+            else {
+                return FailExpectedType(data, fsDataType.Array, fsDataType.Object);
+            }
+
+            return result;
+        }
+
+        public override fsResult TrySerialize(object instance_, out fsData serialized, Type storageType) {
+            serialized = fsData.Null;
+
+            var result = fsResult.Success;
+
+            var instance = (IDictionary)instance_;
+
+            Type keyStorageType, valueStorageType;
+            GetKeyValueTypes(instance.GetType(), out keyStorageType, out valueStorageType);
+
+            // No other way to iterate dictionaries and still have access to the
+            // key/value info
+            IDictionaryEnumerator enumerator = instance.GetEnumerator();
+
+            bool allStringKeys = true;
+            var serializedKeys = new List<fsData>(instance.Count);
+            var serializedValues = new List<fsData>(instance.Count);
+            while (enumerator.MoveNext()) {
+                fsData keyData, valueData;
+                if ((result += Serializer.TrySerialize(keyStorageType, enumerator.Key, out keyData)).Failed) return result;
+                if ((result += Serializer.TrySerialize(valueStorageType, enumerator.Value, out valueData)).Failed) return result;
+
+                serializedKeys.Add(keyData);
+                serializedValues.Add(valueData);
+
+                allStringKeys &= keyData.IsString;
+            }
+
+            if (allStringKeys) {
+                serialized = fsData.CreateDictionary();
+                var serializedDictionary = serialized.AsDictionary;
+
+                for (int i = 0; i < serializedKeys.Count; ++i) {
+                    fsData key = serializedKeys[i];
+                    fsData value = serializedValues[i];
+                    serializedDictionary[key.AsString] = value;
+                }
+            }
+            else {
+                serialized = fsData.CreateList(serializedKeys.Count);
+                var serializedList = serialized.AsList;
+
+                for (int i = 0; i < serializedKeys.Count; ++i) {
+                    fsData key = serializedKeys[i];
+                    fsData value = serializedValues[i];
+
+                    var container = new Dictionary<string, fsData>();
+                    container["Key"] = key;
+                    container["Value"] = value;
+                    serializedList.Add(new fsData(container));
+                }
+            }
+
+            return result;
+        }
+
+        private fsResult AddItemToDictionary(IDictionary dictionary, object key, object value) {
+            // Because we're operating through the IDictionary interface by
+            // default (and not the generic one), we normally send items through
+            // IDictionary.Add(object, object). This works fine in the general
+            // case, except that the add method verifies that it's parameter
+            // types are proper types. However, mono is buggy and these type
+            // checks do not consider null a subtype of the parameter types, and
+            // exceptions get thrown. So, we have to special case adding null
+            // items via the generic functions (which do not do the null check),
+            // which is slow and messy.
+            //
+            // An example of a collection that fails deserialization without this
+            // method is `new SortedList<int, string> { { 0, null } }`.
+            // (SortedDictionary is fine because it properly handles null
+            // values).
+            if (key == null || value == null) {
+                // Life would be much easier if we had MakeGenericType available,
+                // but we don't. So we're going to find the correct generic
+                // KeyValuePair type via a bit of trickery. All dictionaries
+                // extend ICollection<KeyValuePair<TKey, TValue>>, so we just
+                // fetch the ICollection<> type with the proper generic
+                // arguments, and then we take the KeyValuePair<> generic
+                // argument, and whola! we have our proper generic type.
+
+                var collectionType = fsReflectionUtility.GetInterface(dictionary.GetType(), typeof(ICollection<>));
+                if (collectionType == null) {
+                    return fsResult.Warn(dictionary.GetType() + " does not extend ICollection");
+                }
+
+                var keyValuePairType = collectionType.GetGenericArguments()[0];
+                object keyValueInstance = Activator.CreateInstance(keyValuePairType, key, value);
+                MethodInfo add = collectionType.GetFlattenedMethod("Add");
+                add.Invoke(dictionary, new object[] { keyValueInstance });
+                return fsResult.Success;
+            }
+
+            // We use the inline set methods instead of dictionary.Add;
+            // dictionary.Add will throw an exception if the key already exists.
+            dictionary[key] = value;
+            return fsResult.Success;
+        }
+
+        private static void GetKeyValueTypes(Type dictionaryType, out Type keyStorageType, out Type valueStorageType) {
+            // All dictionaries extend IDictionary<TKey, TValue>, so we just
+            // fetch the generic arguments from it
+            var interfaceType = fsReflectionUtility.GetInterface(dictionaryType, typeof(IDictionary<,>));
+            if (interfaceType != null) {
+                var genericArgs = interfaceType.GetGenericArguments();
+                keyStorageType = genericArgs[0];
+                valueStorageType = genericArgs[1];
+            }
+            else {
+                // Fetching IDictionary<,> failed... we have to encode full type
+                // information :(
+                keyStorageType = typeof(object);
+                valueStorageType = typeof(object);
+            }
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsDictionaryConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsDictionaryConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6f364b62fa3618b438cf5dd61bd00a0f
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsEnumConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsEnumConverter.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// Serializes and deserializes enums by their current name.
+    /// </summary>
+    public class fsEnumConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return type.Resolve().IsEnum;
+        }
+
+        public override bool RequestCycleSupport(Type storageType) {
+            return false;
+        }
+
+        public override bool RequestInheritanceSupport(Type storageType) {
+            return false;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            // In .NET compact, Enum.ToObject(Type, Object) is defined but the
+            // overloads like Enum.ToObject(Type, int) are not -- so we get
+            // around this by boxing the value.
+            return Enum.ToObject(storageType, (object)0);
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            if (Serializer.Config.SerializeEnumsAsInteger) {
+                serialized = new fsData(Convert.ToInt64(instance));
+            }
+            else if (fsPortableReflection.GetAttribute<FlagsAttribute>(storageType) != null) {
+                long instanceValue = Convert.ToInt64(instance);
+                var result = new StringBuilder();
+
+                bool first = true;
+                foreach (var value in Enum.GetValues(storageType)) {
+                    long integralValue = Convert.ToInt64(value);
+                    bool isSet = (instanceValue & integralValue) != 0;
+
+                    if (isSet) {
+                        if (first == false) result.Append(",");
+                        first = false;
+                        result.Append(value.ToString());
+                    }
+                }
+
+                serialized = new fsData(result.ToString());
+            }
+            else {
+                serialized = new fsData(Enum.GetName(storageType, instance));
+            }
+            return fsResult.Success;
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            if (data.IsString) {
+                string[] enumValues = data.AsString.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+                long instanceValue = 0;
+                for (int i = 0; i < enumValues.Length; ++i) {
+                    string enumValue = enumValues[i];
+
+                    // Verify that the enum name exists; Enum.TryParse is only
+                    // available in .NET 4.0 and above :(.
+                    if (ArrayContains(Enum.GetNames(storageType), enumValue) == false) {
+                        return fsResult.Fail("Cannot find enum name " + enumValue + " on type " + storageType);
+                    }
+
+                    long flagValue = (long)Convert.ChangeType(Enum.Parse(storageType, enumValue), typeof(long));
+                    instanceValue |= flagValue;
+                }
+
+                instance = Enum.ToObject(storageType, (object)instanceValue);
+                return fsResult.Success;
+            }
+            else if (data.IsInt64) {
+                int enumValue = (int)data.AsInt64;
+
+                // In .NET compact, Enum.ToObject(Type, Object) is defined but
+                // the overloads like Enum.ToObject(Type, int) are not -- so we
+                // get around this by boxing the value.
+                instance = Enum.ToObject(storageType, (object)enumValue);
+
+                return fsResult.Success;
+            }
+
+            return fsResult.Fail("EnumConverter encountered an unknown JSON data type");
+        }
+
+        /// <summary>
+        /// Returns true if the given value is contained within the specified
+        /// array.
+        /// </summary>
+        private static bool ArrayContains<T>(T[] values, T value) {
+            // note: We don't use LINQ because this function will *not* allocate
+            for (int i = 0; i < values.Length; ++i) {
+                if (EqualityComparer<T>.Default.Equals(values[i], value)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsEnumConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsEnumConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b9b18d8643e0d0f45a42e7736c412559
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsForwardConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsForwardConverter.cs
@@ -1,0 +1,90 @@
+﻿using System;
+
+namespace FullSerializer {
+    /// <summary>
+    /// This allows you to forward serialization of an object to one of its
+    /// members. For example,
+    ///
+    /// [fsForward("Values")]
+    /// struct Wrapper {
+    ///     public int[] Values;
+    /// }
+    ///
+    /// Then `Wrapper` will be serialized into a JSON array of integers. It will
+    /// be as if `Wrapper` doesn't exist.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct)]
+    public sealed class fsForwardAttribute : Attribute {
+        /// <summary>
+        /// The name of the member we should serialize as.
+        /// </summary>
+        public string MemberName;
+
+        /// <summary>
+        /// Forward object serialization to an instance member. See class
+        /// comment.
+        /// </summary>
+        /// <param name="memberName">
+        /// The name of the member that we should serialize this object as.
+        /// </param>
+        public fsForwardAttribute(string memberName) {
+            MemberName = memberName;
+        }
+    }
+}
+
+namespace FullSerializer.Internal {
+    public class fsForwardConverter : fsConverter {
+        private string _memberName;
+
+        public fsForwardConverter(fsForwardAttribute attribute) {
+            _memberName = attribute.MemberName;
+        }
+
+        public override bool CanProcess(Type type) {
+            throw new NotSupportedException("Please use the [fsForward(...)] attribute.");
+        }
+
+        private fsResult GetProperty(object instance, out fsMetaProperty property) {
+            var properties = fsMetaType.Get(Serializer.Config, instance.GetType()).Properties;
+            for (int i = 0; i < properties.Length; ++i) {
+                if (properties[i].MemberName == _memberName) {
+                    property = properties[i];
+                    return fsResult.Success;
+                }
+            }
+
+            property = default(fsMetaProperty);
+            return fsResult.Fail("No property named \"" + _memberName + "\" on " + instance.GetType().CSharpName());
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            serialized = fsData.Null;
+            var result = fsResult.Success;
+
+            fsMetaProperty property;
+            if ((result += GetProperty(instance, out property)).Failed) return result;
+
+            var actualInstance = property.Read(instance);
+            return Serializer.TrySerialize(property.StorageType, actualInstance, out serialized);
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            var result = fsResult.Success;
+
+            fsMetaProperty property;
+            if ((result += GetProperty(instance, out property)).Failed) return result;
+
+            object actualInstance = null;
+            if ((result += Serializer.TryDeserialize(data, property.StorageType, ref actualInstance)).Failed)
+                return result;
+
+            property.Write(instance, actualInstance);
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return fsMetaType.Get(Serializer.Config, storageType).CreateInstance();
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsForwardConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsForwardConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7eccd27d395a3b445900ce1a85cc679a
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsGuidConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsGuidConverter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// Serializes and deserializes guids.
+    /// </summary>
+    public class fsGuidConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return type == typeof(Guid);
+        }
+
+        public override bool RequestCycleSupport(Type storageType) {
+            return false;
+        }
+
+        public override bool RequestInheritanceSupport(Type storageType) {
+            return false;
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            var guid = (Guid)instance;
+            serialized = new fsData(guid.ToString());
+            return fsResult.Success;
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            if (data.IsString) {
+                instance = new Guid(data.AsString);
+                return fsResult.Success;
+            }
+
+            return fsResult.Fail("fsGuidConverter encountered an unknown JSON data type");
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new Guid();
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsGuidConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsGuidConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 25223074bdc15f64c9c7c147346b40d0
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsIEnumerableConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsIEnumerableConverter.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// Provides serialization support for anything which extends from
+    /// `IEnumerable` and has an `Add` method.
+    /// </summary>
+    public class fsIEnumerableConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            if (typeof(IEnumerable).IsAssignableFrom(type) == false) return false;
+            return GetAddMethod(type) != null;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return fsMetaType.Get(Serializer.Config, storageType).CreateInstance();
+        }
+
+        public override fsResult TrySerialize(object instance_, out fsData serialized, Type storageType) {
+            var instance = (IEnumerable)instance_;
+            var result = fsResult.Success;
+
+            Type elementType = GetElementType(storageType);
+
+            serialized = fsData.CreateList(HintSize(instance));
+            var serializedList = serialized.AsList;
+
+            foreach (object item in instance) {
+                fsData itemData;
+
+                // note: We don't fail the entire deserialization even if the
+                //       item failed
+                var itemResult = Serializer.TrySerialize(elementType, item, out itemData);
+                result.AddMessages(itemResult);
+                if (itemResult.Failed) continue;
+
+                serializedList.Add(itemData);
+            }
+
+            // Stacks iterate from back to front, which means when we deserialize
+            // we will deserialize the items in the wrong order, so the stack
+            // will get reversed.
+            if (IsStack(instance.GetType())) {
+                serializedList.Reverse();
+            }
+
+            return result;
+        }
+
+        private bool IsStack(Type type) {
+            return type.Resolve().IsGenericType &&
+                   type.Resolve().GetGenericTypeDefinition() == typeof(Stack<>);
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance_, Type storageType) {
+            var instance = (IEnumerable)instance_;
+            var result = fsResult.Success;
+
+            if ((result += CheckType(data, fsDataType.Array)).Failed) return result;
+
+            // For general strategy, instance may already have items in it. We
+            // will try to deserialize into the existing element.
+            var elementStorageType = GetElementType(storageType);
+            var addMethod = GetAddMethod(storageType);
+            var getMethod = storageType.GetFlattenedMethod("get_Item");
+            var setMethod = storageType.GetFlattenedMethod("set_Item");
+            if (setMethod == null) TryClear(storageType, instance);
+            var existingSize = TryGetExistingSize(storageType, instance);
+
+            var serializedList = data.AsList;
+            for (int i = 0; i < serializedList.Count; ++i) {
+                var itemData = serializedList[i];
+                object itemInstance = null;
+                if (getMethod != null && i < existingSize) {
+                    itemInstance = getMethod.Invoke(instance, new object[] { i });
+                }
+
+                // note: We don't fail the entire deserialization even if the
+                //       item failed
+                var itemResult = Serializer.TryDeserialize(itemData, elementStorageType, ref itemInstance);
+                result.AddMessages(itemResult);
+                if (itemResult.Failed) continue;
+
+                if (setMethod != null && i < existingSize) {
+                    setMethod.Invoke(instance, new object[] { i, itemInstance });
+                }
+                else {
+                    addMethod.Invoke(instance, new object[] { itemInstance });
+                }
+            }
+
+            return result;
+        }
+
+        private static int HintSize(IEnumerable collection) {
+            if (collection is ICollection) {
+                return ((ICollection)collection).Count;
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Fetches the element type for objects inside of the collection.
+        /// </summary>
+        private static Type GetElementType(Type objectType) {
+            if (objectType.HasElementType) return objectType.GetElementType();
+
+            Type enumerableList = fsReflectionUtility.GetInterface(objectType, typeof(IEnumerable<>));
+            if (enumerableList != null) return enumerableList.GetGenericArguments()[0];
+
+            return typeof(object);
+        }
+
+        private static void TryClear(Type type, object instance) {
+            var clear = type.GetFlattenedMethod("Clear");
+            if (clear != null) {
+                clear.Invoke(instance, null);
+            }
+        }
+
+        private static int TryGetExistingSize(Type type, object instance) {
+            var count = type.GetFlattenedProperty("Count");
+            if (count != null) {
+                return (int)count.GetGetMethod().Invoke(instance, null);
+            }
+            return 0;
+        }
+
+        private static MethodInfo GetAddMethod(Type type) {
+            // There is a really good chance the type will extend ICollection{},
+            // which will contain the add method we want. Just doing
+            // type.GetFlattenedMethod() may return the incorrect one -- for
+            // example, with dictionaries, it'll return Add(TKey, TValue), and we
+            // want Add(KeyValuePair<TKey, TValue>).
+            Type collectionInterface = fsReflectionUtility.GetInterface(type, typeof(ICollection<>));
+            if (collectionInterface != null) {
+                MethodInfo add = collectionInterface.GetDeclaredMethod("Add");
+                if (add != null) return add;
+            }
+
+            // Otherwise try and look up a general Add method.
+            return
+                type.GetFlattenedMethod("Add") ??
+                type.GetFlattenedMethod("Push") ??
+                type.GetFlattenedMethod("Enqueue");
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsIEnumerableConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsIEnumerableConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d9b9009ce07beeb4cab11ab8019d8f25
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsKeyValuePairConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsKeyValuePairConverter.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace FullSerializer.Internal {
+    public class fsKeyValuePairConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return
+                type.Resolve().IsGenericType &&
+                type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>);
+        }
+
+        public override bool RequestCycleSupport(Type storageType) {
+            return false;
+        }
+
+        public override bool RequestInheritanceSupport(Type storageType) {
+            return false;
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            var result = fsResult.Success;
+
+            fsData keyData, valueData;
+            if ((result += CheckKey(data, "Key", out keyData)).Failed) return result;
+            if ((result += CheckKey(data, "Value", out valueData)).Failed) return result;
+
+            var genericArguments = storageType.GetGenericArguments();
+            Type keyType = genericArguments[0], valueType = genericArguments[1];
+
+            object keyObject = null, valueObject = null;
+            result.AddMessages(Serializer.TryDeserialize(keyData, keyType, ref keyObject));
+            result.AddMessages(Serializer.TryDeserialize(valueData, valueType, ref valueObject));
+
+            instance = Activator.CreateInstance(storageType, keyObject, valueObject);
+            return result;
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            PropertyInfo keyProperty = storageType.GetDeclaredProperty("Key");
+            PropertyInfo valueProperty = storageType.GetDeclaredProperty("Value");
+
+            object keyObject = keyProperty.GetValue(instance, null);
+            object valueObject = valueProperty.GetValue(instance, null);
+
+            var genericArguments = storageType.GetGenericArguments();
+            Type keyType = genericArguments[0], valueType = genericArguments[1];
+
+            var result = fsResult.Success;
+
+            fsData keyData, valueData;
+            result.AddMessages(Serializer.TrySerialize(keyType, keyObject, out keyData));
+            result.AddMessages(Serializer.TrySerialize(valueType, valueObject, out valueData));
+
+            serialized = fsData.CreateDictionary();
+            if (keyData != null) serialized.AsDictionary["Key"] = keyData;
+            if (valueData != null) serialized.AsDictionary["Value"] = valueData;
+
+            return result;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsKeyValuePairConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsKeyValuePairConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2611d96db6a6370458d57e180a2ffe30
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsNullableConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsNullableConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// The reflected converter will properly serialize nullable types. However,
+    /// we do it here instead as we can emit less serialization data.
+    /// </summary>
+    public class fsNullableConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return
+                type.Resolve().IsGenericType &&
+                type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            // null is automatically serialized
+            return Serializer.TrySerialize(Nullable.GetUnderlyingType(storageType), instance, out serialized);
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            // null is automatically deserialized
+            return Serializer.TryDeserialize(data, Nullable.GetUnderlyingType(storageType), ref instance);
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return storageType;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsNullableConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsNullableConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a18dfa892d8de7245824898c553a516b
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsPrimitiveConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsPrimitiveConverter.cs
@@ -1,0 +1,127 @@
+﻿using System;
+
+namespace FullSerializer.Internal {
+    public class fsPrimitiveConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return
+                type.Resolve().IsPrimitive ||
+                type == typeof(string) ||
+                type == typeof(decimal);
+        }
+
+        public override bool RequestCycleSupport(Type storageType) {
+            return false;
+        }
+
+        public override bool RequestInheritanceSupport(Type storageType) {
+            return false;
+        }
+
+        private static bool UseBool(Type type) {
+            return type == typeof(bool);
+        }
+
+        private static bool UseInt64(Type type) {
+            return type == typeof(sbyte) || type == typeof(byte) ||
+                   type == typeof(Int16) || type == typeof(UInt16) ||
+                   type == typeof(Int32) || type == typeof(UInt32) ||
+                   type == typeof(Int64) || type == typeof(UInt64);
+        }
+
+        private static bool UseDouble(Type type) {
+            return type == typeof(float) ||
+                   type == typeof(double) ||
+                   type == typeof(decimal);
+        }
+
+        private static bool UseString(Type type) {
+            return type == typeof(string) ||
+                   type == typeof(char);
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            var instanceType = instance.GetType();
+
+            if (Serializer.Config.Serialize64BitIntegerAsString && (instanceType == typeof(Int64) || instanceType == typeof(UInt64))) {
+                serialized = new fsData((string)Convert.ChangeType(instance, typeof(string)));
+                return fsResult.Success;
+            }
+
+            if (UseBool(instanceType)) {
+                serialized = new fsData((bool)instance);
+                return fsResult.Success;
+            }
+
+            if (UseInt64(instanceType)) {
+                serialized = new fsData((Int64)Convert.ChangeType(instance, typeof(Int64)));
+                return fsResult.Success;
+            }
+
+            if (UseDouble(instanceType)) {
+                // Casting from float to double introduces floating point jitter,
+                // ie, 0.1 becomes 0.100000001490116. Casting to decimal as an
+                // intermediate step removes the jitter. Not sure why.
+                if (instance.GetType() == typeof(float) &&
+                    // Decimal can't store
+                    // float.MinValue/float.MaxValue/float.PositiveInfinity/float.NegativeInfinity/float.NaN
+                    // - an exception gets thrown in that scenario.
+                    (float)instance != float.MinValue &&
+                    (float)instance != float.MaxValue &&
+                    !float.IsInfinity((float)instance) &&
+                    !float.IsNaN((float)instance)
+                    ) {
+                    serialized = new fsData((double)(decimal)(float)instance);
+                    return fsResult.Success;
+                }
+
+                serialized = new fsData((double)Convert.ChangeType(instance, typeof(double)));
+                return fsResult.Success;
+            }
+
+            if (UseString(instanceType)) {
+                serialized = new fsData((string)Convert.ChangeType(instance, typeof(string)));
+                return fsResult.Success;
+            }
+
+            serialized = null;
+            return fsResult.Fail("Unhandled primitive type " + instance.GetType());
+        }
+
+        public override fsResult TryDeserialize(fsData storage, ref object instance, Type storageType) {
+            var result = fsResult.Success;
+
+            if (UseBool(storageType)) {
+                if ((result += CheckType(storage, fsDataType.Boolean)).Succeeded) {
+                    instance = storage.AsBool;
+                }
+                return result;
+            }
+
+            if (UseDouble(storageType) || UseInt64(storageType)) {
+                if (storage.IsDouble) {
+                    instance = Convert.ChangeType(storage.AsDouble, storageType);
+                }
+                else if (storage.IsInt64) {
+                    instance = Convert.ChangeType(storage.AsInt64, storageType);
+                }
+                else if (Serializer.Config.Serialize64BitIntegerAsString && storage.IsString &&
+                    (storageType == typeof(Int64) || storageType == typeof(UInt64))) {
+                    instance = Convert.ChangeType(storage.AsString, storageType);
+                }
+                else {
+                    return fsResult.Fail(GetType().Name + " expected number but got " + storage.Type + " in " + storage);
+                }
+                return fsResult.Success;
+            }
+
+            if (UseString(storageType)) {
+                if ((result += CheckType(storage, fsDataType.String)).Succeeded) {
+                    instance = storage.AsString;
+                }
+                return result;
+            }
+
+            return fsResult.Fail(GetType().Name + ": Bad data; expected bool, number, string, but got " + storage);
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsPrimitiveConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsPrimitiveConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 14030fd201904564584a2639fafcdcfc
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsReflectedConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsReflectedConverter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections;
+
+#if !UNITY_EDITOR && UNITY_WSA
+// For System.Reflection.TypeExtensions
+using System.Reflection;
+#endif
+
+namespace FullSerializer.Internal {
+    public class fsReflectedConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            if (type.Resolve().IsArray ||
+                typeof(ICollection).IsAssignableFrom(type)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            serialized = fsData.CreateDictionary();
+            var result = fsResult.Success;
+
+            fsMetaType metaType = fsMetaType.Get(Serializer.Config, instance.GetType());
+            metaType.EmitAotData(/*throwException:*/ false);
+
+            for (int i = 0; i < metaType.Properties.Length; ++i) {
+                fsMetaProperty property = metaType.Properties[i];
+                if (property.CanRead == false) continue;
+
+                fsData serializedData;
+
+                var itemResult = Serializer.TrySerialize(property.StorageType, property.OverrideConverterType,
+                                                         property.Read(instance), out serializedData);
+                result.AddMessages(itemResult);
+                if (itemResult.Failed) {
+                    continue;
+                }
+
+                serialized.AsDictionary[property.JsonName] = serializedData;
+            }
+
+            return result;
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            var result = fsResult.Success;
+
+            // Verify that we actually have an Object
+            if ((result += CheckType(data, fsDataType.Object)).Failed) {
+                return result;
+            }
+
+            fsMetaType metaType = fsMetaType.Get(Serializer.Config, storageType);
+            metaType.EmitAotData(/*throwException:*/ false);
+
+            for (int i = 0; i < metaType.Properties.Length; ++i) {
+                fsMetaProperty property = metaType.Properties[i];
+                if (property.CanWrite == false) continue;
+
+                fsData propertyData;
+                if (data.AsDictionary.TryGetValue(property.JsonName, out propertyData)) {
+                    object deserializedValue = null;
+
+                    // We have to read in the existing value, since we need to
+                    // support partial deserialization. However, this is bad for
+                    // perf.
+                    // TODO: Find a way to avoid this call when we are not doing
+                    //       a partial deserialization Maybe through a new
+                    //       property, ie, Serializer.IsPartialSerialization,
+                    //       which just gets set when starting a new
+                    //       serialization? We cannot pipe the information
+                    //       through CreateInstance unfortunately.
+                    if (property.CanRead) {
+                        deserializedValue = property.Read(instance);
+                    }
+
+                    var itemResult = Serializer.TryDeserialize(propertyData, property.StorageType,
+                                                               property.OverrideConverterType, ref deserializedValue);
+                    result.AddMessages(itemResult);
+                    if (itemResult.Failed) continue;
+
+                    property.Write(instance, deserializedValue);
+                }
+            }
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            fsMetaType metaType = fsMetaType.Get(Serializer.Config, storageType);
+            return metaType.CreateInstance();
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsReflectedConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsReflectedConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7ff9fcf67634b1b448fa901325a9510d
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsTypeConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsTypeConverter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+#if !UNITY_EDITOR && UNITY_WSA
+// For System.Reflection.TypeExtensions
+using System.Reflection;
+#endif
+
+namespace FullSerializer.Internal {
+    public class fsTypeConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return typeof(Type).IsAssignableFrom(type);
+        }
+
+        public override bool RequestCycleSupport(Type type) {
+            return false;
+        }
+
+        public override bool RequestInheritanceSupport(Type type) {
+            return false;
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            var type = (Type)instance;
+            serialized = new fsData(type.FullName);
+            return fsResult.Success;
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            if (data.IsString == false) {
+                return fsResult.Fail("Type converter requires a string");
+            }
+
+            instance = fsTypeCache.GetType(data.AsString);
+            if (instance == null) {
+                return fsResult.Fail("Unable to find type " + data.AsString);
+            }
+            return fsResult.Success;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return storageType;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsTypeConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsTypeConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9b7c8e9a78b8bb24d9cd168134ba2d3f
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsWeakReferenceConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsWeakReferenceConverter.cs
@@ -1,0 +1,65 @@
+﻿using System;
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// Serializes and deserializes WeakReferences.
+    /// </summary>
+    public class fsWeakReferenceConverter : fsConverter {
+        public override bool CanProcess(Type type) {
+            return type == typeof(WeakReference);
+        }
+
+        public override bool RequestCycleSupport(Type storageType) {
+            return false;
+        }
+
+        public override bool RequestInheritanceSupport(Type storageType) {
+            return false;
+        }
+
+        public override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            var weakRef = (WeakReference)instance;
+
+            var result = fsResult.Success;
+            serialized = fsData.CreateDictionary();
+
+            if (weakRef.IsAlive) {
+                fsData data;
+                if ((result += Serializer.TrySerialize(weakRef.Target, out data)).Failed) {
+                    return result;
+                }
+
+                serialized.AsDictionary["Target"] = data;
+                serialized.AsDictionary["TrackResurrection"] = new fsData(weakRef.TrackResurrection);
+            }
+
+            return result;
+        }
+
+        public override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            var result = fsResult.Success;
+
+            if ((result += CheckType(data, fsDataType.Object)).Failed) return result;
+
+            if (data.AsDictionary.ContainsKey("Target")) {
+                var targetData = data.AsDictionary["Target"];
+                object targetInstance = null;
+
+                if ((result += Serializer.TryDeserialize(targetData, typeof(object), ref targetInstance)).Failed) return result;
+
+                bool trackResurrection = false;
+                if (data.AsDictionary.ContainsKey("TrackResurrection") && data.AsDictionary["TrackResurrection"].IsBool) {
+                    trackResurrection = data.AsDictionary["TrackResurrection"].AsBool;
+                }
+
+                instance = new WeakReference(targetInstance, trackResurrection);
+            }
+
+            return result;
+        }
+
+        public override object CreateInstance(fsData data, Type storageType) {
+            return new WeakReference(null);
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Converters/fsWeakReferenceConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Converters/fsWeakReferenceConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d522279c90b14504f9a25467442f9981
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Internal.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ae1efb8bd6dfa4040beb12118e625b35
+folderAsset: yes
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsCyclicReferenceManager.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsCyclicReferenceManager.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace FullSerializer.Internal {
+    public class fsCyclicReferenceManager {
+        // We use the default ReferenceEquals when comparing two objects because
+        // custom objects may override equals methods. These overriden equals may
+        // treat equals differently; we want to serialize/deserialize the object
+        // graph *identically* to how it currently exists.
+        class ObjectReferenceEqualityComparator : IEqualityComparer<object> {
+            bool IEqualityComparer<object>.Equals(object x, object y) {
+                return ReferenceEquals(x, y);
+            }
+
+            int IEqualityComparer<object>.GetHashCode(object obj) {
+                return RuntimeHelpers.GetHashCode(obj);
+            }
+
+            public static readonly IEqualityComparer<object> Instance = new ObjectReferenceEqualityComparator();
+        }
+
+        private Dictionary<object, int> _objectIds = new Dictionary<object, int>(ObjectReferenceEqualityComparator.Instance);
+        private int _nextId;
+
+        private Dictionary<int, object> _marked = new Dictionary<int, object>();
+        private int _depth;
+
+        public void Enter() {
+            _depth++;
+        }
+
+        public bool Exit() {
+            _depth--;
+
+            if (_depth == 0) {
+                _objectIds = new Dictionary<object, int>(ObjectReferenceEqualityComparator.Instance);
+                _nextId = 0;
+                _marked = new Dictionary<int, object>();
+            }
+
+            if (_depth < 0) {
+                _depth = 0;
+                throw new InvalidOperationException("Internal Error - Mismatched Enter/Exit. Please report a bug at https://github.com/jacobdufault/fullserializer/issues with the serialization data.");
+            }
+
+            return _depth == 0;
+        }
+
+        public object GetReferenceObject(int id) {
+            if (_marked.ContainsKey(id) == false) {
+                throw new InvalidOperationException("Internal Deserialization Error - Object " +
+                    "definition has not been encountered for object with id=" + id +
+                    "; have you reordered or modified the serialized data? If this is an issue " +
+                    "with an unmodified Full Serializer implementation and unmodified serialization " +
+                    "data, please report an issue with an included test case.");
+            }
+
+            return _marked[id];
+        }
+
+        public void AddReferenceWithId(int id, object reference) {
+            _marked[id] = reference;
+        }
+
+        public int GetReferenceId(object item) {
+            int id;
+            if (_objectIds.TryGetValue(item, out id) == false) {
+                id = _nextId++;
+                _objectIds[item] = id;
+            }
+            return id;
+        }
+
+        public bool IsReference(object item) {
+            return _marked.ContainsKey(GetReferenceId(item));
+        }
+
+        public void MarkSerialized(object item) {
+            int referenceId = GetReferenceId(item);
+
+            if (_marked.ContainsKey(referenceId)) {
+                throw new InvalidOperationException("Internal Error - " + item +
+                    " has already been marked as serialized");
+            }
+
+            _marked[referenceId] = item;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsCyclicReferenceManager.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsCyclicReferenceManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1c1dc6d180e2a624fb5ced24b343caac
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsOption.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsOption.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// Simple option type. This is akin to nullable types.
+    /// </summary>
+    public struct fsOption<T> {
+        private bool _hasValue;
+        private T _value;
+
+        public bool HasValue {
+            get { return _hasValue; }
+        }
+        public bool IsEmpty {
+            get { return _hasValue == false; }
+        }
+        public T Value {
+            get {
+                if (IsEmpty) throw new InvalidOperationException("fsOption is empty");
+                return _value;
+            }
+        }
+
+        public fsOption(T value) {
+            _hasValue = true;
+            _value = value;
+        }
+
+        public static fsOption<T> Empty;
+    }
+
+    public static class fsOption {
+        public static fsOption<T> Just<T>(T value) {
+            return new fsOption<T>(value);
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsOption.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsOption.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cb4638b0e5989604ca0d3801ab74bb4f
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsPortableReflection.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsPortableReflection.cs
@@ -1,0 +1,410 @@
+﻿#if !UNITY_EDITOR && UNITY_METRO && !ENABLE_IL2CPP
+#define USE_TYPEINFO
+#if !UNITY_WINRT_10_0
+#define USE_TYPEINFO_EXTENSIONS
+#endif
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
+
+#if USE_TYPEINFO
+namespace System {
+    public static class AssemblyExtensions {
+#if USE_TYPEINFO_EXTENSIONS
+        public static Type[] GetTypes(this Assembly assembly) {
+            TypeInfo[] infos = assembly.DefinedTypes.ToArray();
+            Type[] types = new Type[infos.Length];
+            for (int i = 0; i < infos.Length; ++i) {
+                types[i] = infos[i].AsType();
+            }
+            return types;
+        }
+#endif
+
+        public static Type GetType(this Assembly assembly, string name, bool throwOnError) {
+            var types = assembly.GetTypes();
+            foreach (var type in types) {
+                if (type.Name == name) {
+                    return type.GetType();
+                }
+            }
+
+            if (throwOnError) throw new Exception("Type " + name + " was not found");
+            return null;
+        }
+    }
+}
+#endif
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// This wraps reflection types so that it is portable across different Unity
+    /// runtimes.
+    /// </summary>
+    public static class fsPortableReflection {
+        public static Type[] EmptyTypes = { };
+
+        #region Attribute Queries
+#if USE_TYPEINFO
+        public static TAttribute GetAttribute<TAttribute>(Type type)
+            where TAttribute : Attribute {
+            return GetAttribute<TAttribute>(type.GetTypeInfo());
+        }
+
+        public static Attribute GetAttribute(Type type, Type attributeType) {
+            return GetAttribute(type.GetTypeInfo(), attributeType, /*shouldCache:*/false);
+        }
+
+        public static bool HasAttribute(Type type, Type attributeType) {
+            return GetAttribute(type, attributeType) != null;
+        }
+#endif
+
+        /// <summary>
+        /// Returns true if the given attribute is defined on the given element.
+        /// </summary>
+        public static bool HasAttribute<TAttribute>(MemberInfo element) {
+            return HasAttribute(element, typeof(TAttribute));
+        }
+
+        /// <summary>
+        /// Returns true if the given attribute is defined on the given element.
+        /// </summary>
+        public static bool HasAttribute<TAttribute>(MemberInfo element, bool shouldCache) {
+            return HasAttribute(element, typeof(TAttribute), shouldCache);
+        }
+
+        /// <summary>
+        /// Returns true if the given attribute is defined on the given element.
+        /// </summary>
+        public static bool HasAttribute(MemberInfo element, Type attributeType) {
+            return HasAttribute(element, attributeType, true);
+        }
+
+        /// <summary>
+        /// Returns true if the given attribute is defined on the given element.
+        /// </summary>
+        public static bool HasAttribute(MemberInfo element, Type attributeType, bool shouldCache) {
+            return element.IsDefined(attributeType, true);
+        }
+
+        /// <summary>
+        /// Fetches the given attribute from the given MemberInfo. This method
+        /// applies caching and is allocation free (after caching has been
+        /// performed).
+        /// </summary>
+        /// <param name="element">
+        /// The MemberInfo the get the attribute from.
+        /// </param>
+        /// <param name="attributeType">The type of attribute to fetch.</param>
+        /// <returns>The attribute or null.</returns>
+        public static Attribute GetAttribute(MemberInfo element, Type attributeType, bool shouldCache) {
+            var query = new AttributeQuery {
+                MemberInfo = element,
+                AttributeType = attributeType
+            };
+
+            Attribute attribute;
+            if (_cachedAttributeQueries.TryGetValue(query, out attribute) == false) {
+                var attributes = element.GetCustomAttributes(attributeType, /*inherit:*/ true);
+                if (attributes.Any())
+                    attribute = (Attribute)attributes.First();
+                if (shouldCache)
+                    _cachedAttributeQueries[query] = attribute;
+            }
+
+            return attribute;
+        }
+
+        /// <summary>
+        /// Fetches the given attribute from the given MemberInfo.
+        /// </summary>
+        /// <typeparam name="TAttribute">
+        /// The type of attribute to fetch.
+        /// </typeparam>
+        /// <param name="element">
+        /// The MemberInfo to get the attribute from.
+        /// </param>
+        /// <param name="shouldCache">
+        /// Should this computation be cached? If this is the only time it will
+        /// ever be done, don't bother caching.
+        /// </param>
+        /// <returns>The attribute or null.</returns>
+        public static TAttribute GetAttribute<TAttribute>(MemberInfo element, bool shouldCache)
+            where TAttribute : Attribute {
+            return (TAttribute)GetAttribute(element, typeof(TAttribute), shouldCache);
+        }
+        public static TAttribute GetAttribute<TAttribute>(MemberInfo element)
+            where TAttribute : Attribute {
+            return GetAttribute<TAttribute>(element, /*shouldCache:*/true);
+        }
+        private struct AttributeQuery {
+            public MemberInfo MemberInfo;
+            public Type AttributeType;
+        }
+        private static IDictionary<AttributeQuery, Attribute> _cachedAttributeQueries =
+            new Dictionary<AttributeQuery, Attribute>(new AttributeQueryComparator());
+        private class AttributeQueryComparator : IEqualityComparer<AttributeQuery> {
+            public bool Equals(AttributeQuery x, AttributeQuery y) {
+                return
+                    x.MemberInfo == y.MemberInfo &&
+                    x.AttributeType == y.AttributeType;
+            }
+
+            public int GetHashCode(AttributeQuery obj) {
+                return
+                    obj.MemberInfo.GetHashCode() +
+                    (17 * obj.AttributeType.GetHashCode());
+            }
+        }
+        #endregion Attribute Queries
+
+#if !USE_TYPEINFO
+        private static BindingFlags DeclaredFlags =
+            BindingFlags.NonPublic |
+            BindingFlags.Public |
+            BindingFlags.Instance |
+            BindingFlags.Static |
+            BindingFlags.DeclaredOnly;
+#endif
+
+        public static PropertyInfo GetDeclaredProperty(this Type type, string propertyName) {
+            var props = GetDeclaredProperties(type);
+
+            for (int i = 0; i < props.Length; ++i) {
+                if (props[i].Name == propertyName) {
+                    return props[i];
+                }
+            }
+
+            return null;
+        }
+
+        public static MethodInfo GetDeclaredMethod(this Type type, string methodName) {
+            var methods = GetDeclaredMethods(type);
+
+            for (int i = 0; i < methods.Length; ++i) {
+                if (methods[i].Name == methodName) {
+                    return methods[i];
+                }
+            }
+
+            return null;
+        }
+
+        public static ConstructorInfo GetDeclaredConstructor(this Type type, Type[] parameters) {
+            var ctors = GetDeclaredConstructors(type);
+
+            for (int i = 0; i < ctors.Length; ++i) {
+                var ctor = ctors[i];
+
+                if (ctor.IsStatic) continue; // Ignore static constructors.
+
+                var ctorParams = ctor.GetParameters();
+
+                if (parameters.Length != ctorParams.Length) continue;
+
+                for (int j = 0; j < ctorParams.Length; ++j) {
+                    // require an exact match
+                    if (ctorParams[j].ParameterType != parameters[j]) continue;
+                }
+
+                return ctor;
+            }
+
+            return null;
+        }
+
+        public static ConstructorInfo[] GetDeclaredConstructors(this Type type) {
+#if USE_TYPEINFO
+            return type.GetTypeInfo().DeclaredConstructors.ToArray();
+#else
+            return type.GetConstructors(DeclaredFlags);
+#endif
+        }
+
+        public static MemberInfo[] GetFlattenedMember(this Type type, string memberName) {
+            var result = new List<MemberInfo>();
+
+            while (type != null) {
+                var members = GetDeclaredMembers(type);
+
+                for (int i = 0; i < members.Length; ++i) {
+                    if (members[i].Name == memberName) {
+                        result.Add(members[i]);
+                    }
+                }
+
+                type = type.Resolve().BaseType;
+            }
+
+            return result.ToArray();
+        }
+
+        public static MethodInfo GetFlattenedMethod(this Type type, string methodName) {
+            while (type != null) {
+                var methods = GetDeclaredMethods(type);
+
+                for (int i = 0; i < methods.Length; ++i) {
+                    if (methods[i].Name == methodName) {
+                        return methods[i];
+                    }
+                }
+
+                type = type.Resolve().BaseType;
+            }
+
+            return null;
+        }
+
+        public static IEnumerable<MethodInfo> GetFlattenedMethods(this Type type, string methodName) {
+            while (type != null) {
+                var methods = GetDeclaredMethods(type);
+
+                for (int i = 0; i < methods.Length; ++i) {
+                    if (methods[i].Name == methodName) {
+                        yield return methods[i];
+                    }
+                }
+
+                type = type.Resolve().BaseType;
+            }
+        }
+
+        public static PropertyInfo GetFlattenedProperty(this Type type, string propertyName) {
+            while (type != null) {
+                var properties = GetDeclaredProperties(type);
+
+                for (int i = 0; i < properties.Length; ++i) {
+                    if (properties[i].Name == propertyName) {
+                        return properties[i];
+                    }
+                }
+
+                type = type.Resolve().BaseType;
+            }
+
+            return null;
+        }
+
+        public static MemberInfo GetDeclaredMember(this Type type, string memberName) {
+            var members = GetDeclaredMembers(type);
+
+            for (int i = 0; i < members.Length; ++i) {
+                if (members[i].Name == memberName) {
+                    return members[i];
+                }
+            }
+
+            return null;
+        }
+
+        public static MethodInfo[] GetDeclaredMethods(this Type type) {
+#if USE_TYPEINFO
+            return type.GetTypeInfo().DeclaredMethods.ToArray();
+#else
+            return type.GetMethods(DeclaredFlags);
+#endif
+        }
+
+        public static PropertyInfo[] GetDeclaredProperties(this Type type) {
+#if USE_TYPEINFO
+            return type.GetTypeInfo().DeclaredProperties.ToArray();
+#else
+            return type.GetProperties(DeclaredFlags);
+#endif
+        }
+
+        public static FieldInfo[] GetDeclaredFields(this Type type) {
+#if USE_TYPEINFO
+            return type.GetTypeInfo().DeclaredFields.ToArray();
+#else
+            return type.GetFields(DeclaredFlags);
+#endif
+        }
+
+        public static MemberInfo[] GetDeclaredMembers(this Type type) {
+#if USE_TYPEINFO
+            return type.GetTypeInfo().DeclaredMembers.ToArray();
+#else
+            return type.GetMembers(DeclaredFlags);
+#endif
+        }
+
+        public static MemberInfo AsMemberInfo(Type type) {
+#if USE_TYPEINFO
+            return type.GetTypeInfo();
+#else
+            return type;
+#endif
+        }
+
+        public static bool IsType(MemberInfo member) {
+#if USE_TYPEINFO
+            return member is TypeInfo;
+#else
+            return member is Type;
+#endif
+        }
+
+        public static Type AsType(MemberInfo member) {
+#if USE_TYPEINFO
+            return ((TypeInfo)member).AsType();
+#else
+            return (Type)member;
+#endif
+        }
+
+#if USE_TYPEINFO
+        public static TypeInfo Resolve(this Type type) {
+            return type.GetTypeInfo();
+        }
+#else
+        public static Type Resolve(this Type type) {
+            return type;
+        }
+#endif
+
+        #region Extensions
+
+#if USE_TYPEINFO_EXTENSIONS
+        public static bool IsAssignableFrom(this Type parent, Type child) {
+            return parent.GetTypeInfo().IsAssignableFrom(child.GetTypeInfo());
+        }
+
+        public static Type GetElementType(this Type type) {
+            return type.GetTypeInfo().GetElementType();
+        }
+
+        public static MethodInfo GetSetMethod(this PropertyInfo member, bool nonPublic = false) {
+            // only public requested but the set method is not public
+            if (nonPublic == false && member.SetMethod != null && member.SetMethod.IsPublic == false) return null;
+
+            return member.SetMethod;
+        }
+
+        public static MethodInfo GetGetMethod(this PropertyInfo member, bool nonPublic = false) {
+            // only public requested but the set method is not public
+            if (nonPublic == false && member.GetMethod != null && member.GetMethod.IsPublic == false) return null;
+
+            return member.GetMethod;
+        }
+
+        public static MethodInfo GetBaseDefinition(this MethodInfo method) {
+            return method.GetRuntimeBaseDefinition();
+        }
+
+        public static Type[] GetInterfaces(this Type type) {
+            return type.GetTypeInfo().ImplementedInterfaces.ToArray();
+        }
+
+        public static Type[] GetGenericArguments(this Type type) {
+            return type.GetTypeInfo().GenericTypeArguments.ToArray();
+        }
+#endif
+        #endregion Extensions
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsPortableReflection.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsPortableReflection.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 53f0d6faef1e74649a1d4ec87281ce9c
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsTypeExtensions.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsTypeExtensions.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#if !UNITY_EDITOR && UNITY_WSA
+// For System.Reflection.TypeExtensions
+using System.Reflection;
+// For Reflection Extensions in non-win10 builds.
+using FullSerializer.Internal;
+#endif
+
+namespace FullSerializer {
+    public static class fsTypeExtensions {
+        /// <summary>
+        /// Returns a pretty name for the type in the style of one that you'd see
+        /// in C# without the namespace.
+        /// </summary>
+        public static string CSharpName(this Type type) {
+            return CSharpName(type, /*includeNamespace:*/false);
+        }
+
+        public static string CSharpName(this Type type, bool includeNamespace, bool ensureSafeDeclarationName) {
+            var name = CSharpName(type, includeNamespace);
+            if (ensureSafeDeclarationName)
+                name = name.Replace('>', '_').Replace('<', '_').Replace('.', '_').Replace(',', '_');
+            return name;
+        }
+
+        /// <summary>
+        /// Returns a pretty name for the type in the style of one that you'd see
+        /// in C#.
+        /// </summary>
+        /// <parparam name="includeNamespace">
+        /// Should the name include namespaces?
+        /// </parparam>
+        public static string CSharpName(this Type type, bool includeNamespace) {
+            // we special case some of the common type names
+            if (type == typeof(void)) return "void";
+            if (type == typeof(int)) return "int";
+            if (type == typeof(float)) return "float";
+            if (type == typeof(bool)) return "bool";
+            if (type == typeof(double)) return "double";
+            if (type == typeof(string)) return "string";
+
+            // Generic parameter, ie, T in Okay<T> We special-case this logic
+            // otherwise we will recurse on the T
+            if (type.IsGenericParameter) {
+                return type.ToString();
+            }
+
+            string name = "";
+
+            var genericArguments = (IEnumerable<Type>)type.GetGenericArguments();
+            if (type.IsNested) {
+                name += type.DeclaringType.CSharpName() + ".";
+
+                // The declaring type generic parameters are considered part of
+                // the nested types generic parameters so we need to remove them,
+                // otherwise it will get included again.
+                //
+                // Say we have type `class Parent<T> { class Child {} }` If we
+                // did not do the removal, then we would output
+                // Parent<T>.Child<T>, but we really want to output
+                // Parent<T>.Child
+                if (type.DeclaringType.GetGenericArguments().Length > 0) {
+                    genericArguments = genericArguments.Skip(type.DeclaringType.GetGenericArguments().Length);
+                }
+            }
+
+            if (genericArguments.Any() == false) {
+                name += type.Name;
+            }
+            else {
+                var genericsTic = type.Name.IndexOf('`');
+                if (genericsTic > 0) {
+                    name += type.Name.Substring(0, genericsTic);
+                }
+                name += "<" + String.Join(",", genericArguments.Select(t => CSharpName(t, includeNamespace)).ToArray()) + ">";
+            }
+
+            if (includeNamespace && type.Namespace != null) {
+                name = type.Namespace + "." + name;
+            }
+
+            return name;
+        }
+
+        public static bool IsInterface(this Type type)
+        {
+#if NETFX_CORE
+            return type.GetTypeInfo().IsInterface;
+#else
+            return type.IsInterface;
+#endif
+        }
+
+        public static bool IsAbstract(this Type type)
+        {
+#if NETFX_CORE
+            return type.GetTypeInfo().IsAbstract;
+#else
+            return type.IsAbstract;
+#endif
+        }
+
+        public static bool IsGenericType(this Type type)
+        {
+#if NETFX_CORE
+            return type.GetTypeInfo().IsGenericType;
+#else
+            return type.IsGenericType;
+#endif
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsTypeExtensions.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsTypeExtensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7c3b8173faf686b44bdf5a3478f776cd
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsVersionManager.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsVersionManager.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace FullSerializer.Internal {
+    public static class fsVersionManager {
+        private static readonly Dictionary<Type, fsOption<fsVersionedType>> _cache = new Dictionary<Type, fsOption<fsVersionedType>>();
+
+        public static fsResult GetVersionImportPath(string currentVersion, fsVersionedType targetVersion, out List<fsVersionedType> path) {
+            path = new List<fsVersionedType>();
+
+            if (GetVersionImportPathRecursive(path, currentVersion, targetVersion) == false) {
+                return fsResult.Fail("There is no migration path from \"" + currentVersion + "\" to \"" + targetVersion.VersionString + "\"");
+            }
+
+            path.Add(targetVersion);
+            return fsResult.Success;
+        }
+
+        private static bool GetVersionImportPathRecursive(List<fsVersionedType> path, string currentVersion, fsVersionedType current) {
+            for (int i = 0; i < current.Ancestors.Length; ++i) {
+                fsVersionedType ancestor = current.Ancestors[i];
+
+                if (ancestor.VersionString == currentVersion ||
+                    GetVersionImportPathRecursive(path, currentVersion, ancestor)) {
+                    path.Add(ancestor);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static fsOption<fsVersionedType> GetVersionedType(Type type) {
+            fsOption<fsVersionedType> optionalVersionedType;
+
+            if (_cache.TryGetValue(type, out optionalVersionedType) == false) {
+                var attr = fsPortableReflection.GetAttribute<fsObjectAttribute>(type);
+
+                if (attr != null) {
+                    if (string.IsNullOrEmpty(attr.VersionString) == false || attr.PreviousModels != null) {
+                        // Version string must be provided
+                        if (attr.PreviousModels != null && string.IsNullOrEmpty(attr.VersionString)) {
+                            throw new Exception("fsObject attribute on " + type + " contains a PreviousModels specifier - it must also include a VersionString modifier");
+                        }
+
+                        // Map the ancestor types into versioned types
+                        fsVersionedType[] ancestors = new fsVersionedType[attr.PreviousModels != null ? attr.PreviousModels.Length : 0];
+                        for (int i = 0; i < ancestors.Length; ++i) {
+                            fsOption<fsVersionedType> ancestorType = GetVersionedType(attr.PreviousModels[i]);
+                            if (ancestorType.IsEmpty) {
+                                throw new Exception("Unable to create versioned type for ancestor " + ancestorType + "; please add an [fsObject(VersionString=\"...\")] attribute");
+                            }
+                            ancestors[i] = ancestorType.Value;
+                        }
+
+                        // construct the actual versioned type instance
+                        fsVersionedType versionedType = new fsVersionedType {
+                            Ancestors = ancestors,
+                            VersionString = attr.VersionString,
+                            ModelType = type
+                        };
+
+                        // finally, verify that the versioned type passes some
+                        // sanity checks
+                        VerifyUniqueVersionStrings(versionedType);
+                        VerifyConstructors(versionedType);
+
+                        optionalVersionedType = fsOption.Just(versionedType);
+                    }
+                }
+
+                _cache[type] = optionalVersionedType;
+            }
+
+            return optionalVersionedType;
+        }
+
+        /// <summary>
+        /// Verifies that the given type has constructors to migrate from all
+        /// ancestor types.
+        /// </summary>
+        private static void VerifyConstructors(fsVersionedType type) {
+            ConstructorInfo[] publicConstructors = type.ModelType.GetDeclaredConstructors();
+
+            for (int i = 0; i < type.Ancestors.Length; ++i) {
+                Type requiredConstructorType = type.Ancestors[i].ModelType;
+
+                bool found = false;
+                for (int j = 0; j < publicConstructors.Length; ++j) {
+                    var parameters = publicConstructors[j].GetParameters();
+                    if (parameters.Length == 1 && parameters[0].ParameterType == requiredConstructorType) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found == false) {
+                    throw new fsMissingVersionConstructorException(type.ModelType, requiredConstructorType);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the given version graph contains only unique versions.
+        /// </summary>
+        private static void VerifyUniqueVersionStrings(fsVersionedType type) {
+            // simple tree traversal
+
+            var found = new Dictionary<string, Type>();
+
+            var remaining = new Queue<fsVersionedType>();
+            remaining.Enqueue(type);
+
+            while (remaining.Count > 0) {
+                fsVersionedType item = remaining.Dequeue();
+
+                // Verify we do not already have the version string. Take into
+                // account that we're not just comparing the same model twice,
+                // since we can have a valid import graph that has the same model
+                // multiple times.
+                if (found.ContainsKey(item.VersionString) && found[item.VersionString] != item.ModelType) {
+                    throw new fsDuplicateVersionNameException(found[item.VersionString], item.ModelType, item.VersionString);
+                }
+                found[item.VersionString] = item.ModelType;
+
+                // scan the ancestors as well
+                foreach (var ancestor in item.Ancestors) {
+                    remaining.Enqueue(ancestor);
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsVersionManager.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsVersionManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 39e37c86cc277f544a0860a95c73c4d6
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsVersionedType.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsVersionedType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace FullSerializer.Internal {
+    public struct fsVersionedType {
+        /// <summary>
+        /// The direct ancestors that this type can import.
+        /// </summary>
+        public fsVersionedType[] Ancestors;
+
+        /// <summary>
+        /// The identifying string that is unique among all ancestors.
+        /// </summary>
+        public string VersionString;
+
+        /// <summary>
+        /// The modeling type that this versioned type maps back to.
+        /// </summary>
+        public Type ModelType;
+
+        /// <summary>
+        /// Migrate from an instance of an ancestor.
+        /// </summary>
+        public object Migrate(object ancestorInstance) {
+            return Activator.CreateInstance(ModelType, ancestorInstance);
+        }
+
+        public override string ToString() {
+            return "fsVersionedType [ModelType=" + ModelType + ", VersionString=" + VersionString + ", Ancestors.Length=" + Ancestors.Length + "]";
+        }
+
+        public static bool operator ==(fsVersionedType a, fsVersionedType b) {
+            return a.ModelType == b.ModelType;
+        }
+
+        public static bool operator !=(fsVersionedType a, fsVersionedType b) {
+            return a.ModelType != b.ModelType;
+        }
+
+        public override bool Equals(object obj) {
+            return
+                obj is fsVersionedType &&
+                ModelType == ((fsVersionedType)obj).ModelType;
+        }
+
+        public override int GetHashCode() {
+            return ModelType.GetHashCode();
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Internal/fsVersionedType.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Internal/fsVersionedType.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ac58601fa737f8048831c6bd75a6fca2
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Reflection.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Reflection.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4f755e4a106fd94a9053c5a49c3600f
+folderAsset: yes
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Reflection/fsMetaProperty.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Reflection/fsMetaProperty.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Reflection;
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// A property or field on a MetaType. This unifies the FieldInfo and
+    /// PropertyInfo classes.
+    /// </summary>
+    public class fsMetaProperty {
+        internal fsMetaProperty(fsConfig config, FieldInfo field) {
+            _memberInfo = field;
+            StorageType = field.FieldType;
+            MemberName = field.Name;
+            IsPublic = field.IsPublic;
+            IsReadOnly = field.IsInitOnly;
+            CanRead = true;
+            CanWrite = true;
+
+            CommonInitialize(config);
+        }
+
+        internal fsMetaProperty(fsConfig config, PropertyInfo property) {
+            _memberInfo = property;
+            StorageType = property.PropertyType;
+            MemberName = property.Name;
+            IsPublic = (property.GetGetMethod() != null && property.GetGetMethod().IsPublic) &&
+                       (property.GetSetMethod() != null && property.GetSetMethod().IsPublic);
+            IsReadOnly = false;
+            CanRead = property.CanRead;
+            CanWrite = property.CanWrite;
+
+            CommonInitialize(config);
+        }
+
+        private void CommonInitialize(fsConfig config) {
+            var attr = fsPortableReflection.GetAttribute<fsPropertyAttribute>(_memberInfo);
+            if (attr != null) {
+                JsonName = attr.Name;
+                OverrideConverterType = attr.Converter;
+            }
+
+            if (string.IsNullOrEmpty(JsonName)) {
+                JsonName = config.GetJsonNameFromMemberName(MemberName, _memberInfo);
+            }
+        }
+
+        /// <summary>
+        /// Internal handle to the reflected member.
+        /// </summary>
+        private MemberInfo _memberInfo;
+
+        /// <summary>
+        /// The type of value that is stored inside of the property. For example,
+        /// for an int field, StorageType will be typeof(int).
+        /// </summary>
+        public Type StorageType {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// A custom fsBaseConverter instance to use for this field/property, if
+        /// requested. This will be null if the default converter selection
+        /// algorithm should be used. This is specified using the [fsObject]
+        /// annotation with the Converter field.
+        /// </summary>
+        public Type OverrideConverterType {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Can this property be read?
+        /// </summary>
+        public bool CanRead {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Can this property be written to?
+        /// </summary>
+        public bool CanWrite {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The serialized name of the property, as it should appear in JSON.
+        /// </summary>
+        public string JsonName {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The name of the actual member.
+        /// </summary>
+        public string MemberName {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Is this member public?
+        /// </summary>
+        public bool IsPublic {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Is this type readonly? We can modify readonly properties using
+        /// reflection, but not using generated C#.
+        /// </summary>
+        public bool IsReadOnly {
+            get; private set;
+        }
+
+        /// <summary>
+        /// Writes a value to the property that this MetaProperty represents,
+        /// using given object instance as the context.
+        /// </summary>
+        public void Write(object context, object value) {
+            FieldInfo field = _memberInfo as FieldInfo;
+            PropertyInfo property = _memberInfo as PropertyInfo;
+
+            if (field != null) {
+                field.SetValue(context, value);
+            }
+            else if (property != null) {
+                MethodInfo setMethod = property.GetSetMethod(/*nonPublic:*/ true);
+                if (setMethod != null) {
+                    setMethod.Invoke(context, new object[] { value });
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reads a value from the property that this MetaProperty represents,
+        /// using the given object instance as the context.
+        /// </summary>
+        public object Read(object context) {
+            if (_memberInfo is PropertyInfo) {
+                return ((PropertyInfo)_memberInfo).GetValue(context, new object[] { });
+            }
+            else {
+                return ((FieldInfo)_memberInfo).GetValue(context);
+            }
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Reflection/fsMetaProperty.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Reflection/fsMetaProperty.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bce2bac5e1b3d9043a6a4207280d7d71
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Reflection/fsMetaType.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Reflection/fsMetaType.cs
@@ -1,0 +1,370 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using FullSerializer.Internal;
+
+namespace FullSerializer {
+    /// <summary>
+    /// MetaType contains metadata about a type. This is used by the reflection
+    /// serializer.
+    /// </summary>
+    public class fsMetaType {
+        private static Dictionary<fsConfig, Dictionary<Type, fsMetaType>> _configMetaTypes =
+            new Dictionary<fsConfig, Dictionary<Type, fsMetaType>>();
+
+        public static fsMetaType Get(fsConfig config, Type type) {
+            Dictionary<Type, fsMetaType> metaTypes;
+            lock (typeof(fsMetaType)) {
+                if (_configMetaTypes.TryGetValue(config, out metaTypes) == false)
+                    metaTypes = _configMetaTypes[config] = new Dictionary<Type, fsMetaType>();
+            }
+
+            fsMetaType metaType;
+            if (metaTypes.TryGetValue(type, out metaType) == false) {
+                metaType = new fsMetaType(config, type);
+                metaTypes[type] = metaType;
+            }
+
+            return metaType;
+        }
+
+        /// <summary>
+        /// Clears out the cached type results. Useful if some prior assumptions
+        /// become invalid, ie, the default member serialization mode.
+        /// </summary>
+        public static void ClearCache() {
+            lock (typeof(fsMetaType)) {
+                _configMetaTypes = new Dictionary<fsConfig, Dictionary<Type, fsMetaType>>();
+            }
+        }
+
+        private fsMetaType(fsConfig config, Type reflectedType) {
+            ReflectedType = reflectedType;
+
+            List<fsMetaProperty> properties = new List<fsMetaProperty>();
+            CollectProperties(config, properties, reflectedType);
+            Properties = properties.ToArray();
+        }
+
+        public Type ReflectedType;
+
+        private static void CollectProperties(fsConfig config, List<fsMetaProperty> properties, Type reflectedType) {
+            // do we require a [SerializeField] or [fsProperty] attribute?
+            bool requireOptIn = config.DefaultMemberSerialization == fsMemberSerialization.OptIn;
+            bool requireOptOut = config.DefaultMemberSerialization == fsMemberSerialization.OptOut;
+
+            fsObjectAttribute attr = fsPortableReflection.GetAttribute<fsObjectAttribute>(reflectedType);
+            if (attr != null) {
+                requireOptIn = attr.MemberSerialization == fsMemberSerialization.OptIn;
+                requireOptOut = attr.MemberSerialization == fsMemberSerialization.OptOut;
+            }
+
+            MemberInfo[] members = reflectedType.GetDeclaredMembers();
+            foreach (var member in members) {
+                // We don't serialize members annotated with any of the ignore
+                // serialize attributes
+                if (config.IgnoreSerializeAttributes.Any(t => fsPortableReflection.HasAttribute(member, t))) {
+                    continue;
+                }
+
+                PropertyInfo property = member as PropertyInfo;
+                FieldInfo field = member as FieldInfo;
+
+                // Early out if it's neither a field or a property, since we
+                // don't serialize anything else.
+                if (property == null && field == null) {
+                    continue;
+                }
+
+                // Skip properties if we don't want them, to avoid the cost of
+                // checking attributes.
+                if (property != null && !config.EnablePropertySerialization) {
+                    continue;
+                }
+
+                // If an opt-in annotation is required, then skip the property if
+                // it doesn't have one of the serialize attributes
+                if (requireOptIn &&
+                    !config.SerializeAttributes.Any(t => fsPortableReflection.HasAttribute(member, t))) {
+                    continue;
+                }
+
+                // If an opt-out annotation is required, then skip the property
+                // *only if* it has one of the not serialize attributes
+                if (requireOptOut &&
+                    config.IgnoreSerializeAttributes.Any(t => fsPortableReflection.HasAttribute(member, t))) {
+                    continue;
+                }
+
+                if (property != null) {
+                    if (CanSerializeProperty(config, property, members, requireOptOut)) {
+                        properties.Add(new fsMetaProperty(config, property));
+                    }
+                }
+                else if (field != null) {
+                    if (CanSerializeField(config, field, requireOptOut)) {
+                        properties.Add(new fsMetaProperty(config, field));
+                    }
+                }
+            }
+
+            if (reflectedType.Resolve().BaseType != null) {
+                CollectProperties(config, properties, reflectedType.Resolve().BaseType);
+            }
+        }
+
+        private static bool IsAutoProperty(PropertyInfo property, MemberInfo[] members) {
+            return
+                property.CanWrite && property.CanRead &&
+                fsPortableReflection.HasAttribute(
+                        property.GetGetMethod(), typeof(CompilerGeneratedAttribute), /*shouldCache:*/false);
+        }
+
+        /// <summary>
+        /// Returns if the given property should be serialized.
+        /// </summary>
+        /// <param name="annotationFreeValue">
+        /// Should a property without any annotations be serialized?
+        /// </param>
+        private static bool CanSerializeProperty(fsConfig config, PropertyInfo property, MemberInfo[] members, bool annotationFreeValue) {
+            // We don't serialize delegates
+            if (typeof(Delegate).IsAssignableFrom(property.PropertyType)) {
+                return false;
+            }
+
+            var publicGetMethod = property.GetGetMethod(/*nonPublic:*/ false);
+            var publicSetMethod = property.GetSetMethod(/*nonPublic:*/ false);
+
+            // We do not bother to serialize static fields.
+            if ((publicGetMethod != null && publicGetMethod.IsStatic) ||
+                (publicSetMethod != null && publicSetMethod.IsStatic)) {
+                return false;
+            }
+
+            // Never serialize indexers. I can't think of a sane way to
+            // serialize/deserialize them, and they're normally wrappers around
+            // other fields anyway...
+            if (property.GetIndexParameters().Length > 0) {
+                return false;
+            }
+
+            // Don't serialize members of types that themselves aren't to be serialized.
+            if (config.IgnoreSerializeTypeAttributes.Any(t => fsPortableReflection.HasAttribute(property.PropertyType, t))) {
+                return false;
+            }
+
+            // If a property is annotated with one of the serializable
+            // attributes, then it should it should definitely be serialized.
+            //
+            // NOTE: We place this override check *after* the static check,
+            //       because we *never* allow statics to be serialized.
+            if (config.SerializeAttributes.Any(t => fsPortableReflection.HasAttribute(property, t))) {
+                return true;
+            }
+
+            // If the property cannot be both read and written to, we are not
+            // going to serialize it regardless of the default serialization mode
+            if (property.CanRead == false || property.CanWrite == false) {
+                return false;
+            }
+
+            // Depending on the configuration options, check whether the property
+            // is automatic and if it has a public setter to determine whether it
+            // should be serialized
+            if ((publicGetMethod != null && (config.SerializeNonPublicSetProperties || publicSetMethod != null)) &&
+                (config.SerializeNonAutoProperties || IsAutoProperty(property, members))) {
+                return true;
+            }
+
+            // Otherwise, we don't bother with serialization
+            return annotationFreeValue;
+        }
+
+        private static bool CanSerializeField(fsConfig config, FieldInfo field, bool annotationFreeValue) {
+            // We don't serialize delegates
+            if (typeof(Delegate).IsAssignableFrom(field.FieldType)) {
+                return false;
+            }
+
+            // We don't serialize compiler generated fields.
+            if (field.IsDefined(typeof(CompilerGeneratedAttribute), false)) {
+                return false;
+            }
+
+            // We don't serialize static fields
+            if (field.IsStatic) {
+                return false;
+            }
+
+            // Don't serialize members of types that themselves aren't to be serialized.
+            if (config.IgnoreSerializeTypeAttributes.Any(t => fsPortableReflection.HasAttribute(field.FieldType, t))) {
+                return false;
+            }
+
+            // We want to serialize any fields annotated with one of the
+            // serialize attributes.
+            //
+            // NOTE: This occurs *after* the static check, because we *never*
+            //       want to serialize static fields.
+            if (config.SerializeAttributes.Any(t => fsPortableReflection.HasAttribute(field, t))) {
+                return true;
+            }
+
+            // We use !IsPublic because that also checks for internal, protected,
+            // and private.
+            if (!annotationFreeValue && !field.IsPublic) {
+                return false;
+            }
+
+            return true;
+        }
+
+        public class AotFailureException : Exception {
+            public AotFailureException(string reason) : base(reason) {}
+        }
+
+        /// <summary>
+        /// Attempt to emit an AOT compiled direct converter for this type.
+        /// </summary>
+        /// <returns>True if AOT data was emitted, false otherwise.</returns>
+        public void EmitAotData(bool throwException) {
+            fsAotCompilationManager.AotCandidateTypes.Add(ReflectedType);
+            if (!throwException)
+                return;
+
+            // NOTE: Even if the type has derived types, we can still
+            // generate a direct converter for it. Direct converters are not
+            // used for inherited types, so the reflected converter or
+            // something similar will be used for the derived type instead of
+            // our AOT compiled one.
+
+            for (int i = 0; i < Properties.Length; ++i) {
+                // Cannot AOT compile since we need to public member access.
+                if (Properties[i].IsPublic == false)
+                    throw new AotFailureException(ReflectedType.CSharpName(true) + "::" + Properties[i].MemberName + " is not public");
+                // Cannot AOT compile since readonly members can only be
+                // modified using reflection.
+                if (Properties[i].IsReadOnly)
+                    throw new AotFailureException(ReflectedType.CSharpName(true) + "::" + Properties[i].MemberName + " is readonly");
+            }
+
+            // Cannot AOT compile since we need a default ctor.
+            if (HasDefaultConstructor == false)
+                throw new AotFailureException(ReflectedType.CSharpName(true) + " does not have a default constructor");
+        }
+
+        public fsMetaProperty[] Properties {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Returns true if the type represented by this metadata contains a
+        /// default constructor.
+        /// </summary>
+        public bool HasDefaultConstructor {
+            get {
+                if (_hasDefaultConstructorCache.HasValue == false) {
+                    // arrays are considered to have a default constructor
+                    if (ReflectedType.Resolve().IsArray) {
+                        _hasDefaultConstructorCache = true;
+                        _isDefaultConstructorPublicCache = true;
+                    }
+
+                    // value types (ie, structs) always have a default
+                    // constructor
+                    else if (ReflectedType.Resolve().IsValueType) {
+                        _hasDefaultConstructorCache = true;
+                        _isDefaultConstructorPublicCache = true;
+                    }
+                    else {
+                        // consider private constructors as well
+                        var ctor = ReflectedType.GetDeclaredConstructor(fsPortableReflection.EmptyTypes);
+                        _hasDefaultConstructorCache = ctor != null;
+                        if (ctor != null) {
+                            _isDefaultConstructorPublicCache = ctor.IsPublic;
+                        }
+                    }
+                }
+
+                return _hasDefaultConstructorCache.Value;
+            }
+        }
+        public bool IsDefaultConstructorPublic {
+            get {
+                if (_isDefaultConstructorPublicCache.HasValue == false) {
+                    var t = HasDefaultConstructor;
+                }
+                return _isDefaultConstructorPublicCache.Value;
+            }
+        }
+        private bool? _hasDefaultConstructorCache;
+        private bool? _isDefaultConstructorPublicCache;
+
+        /// <summary>
+        /// Creates a new instance of the type that this metadata points back to.
+        /// If this type has a default constructor, then Activator.CreateInstance
+        /// will be used to construct the type (or Array.CreateInstance if it an
+        /// array). Otherwise, an uninitialized object created via
+        /// FormatterServices.GetSafeUninitializedObject is used to construct the
+        /// instance.
+        /// </summary>
+        public object CreateInstance() {
+            if (ReflectedType.Resolve().IsInterface || ReflectedType.Resolve().IsAbstract) {
+                throw new Exception("Cannot create an instance of an interface or abstract type for " + ReflectedType);
+            }
+
+#if !NO_UNITY
+            // Unity requires special construction logic for types that derive
+            // from ScriptableObject.
+            if (typeof(UnityEngine.ScriptableObject).IsAssignableFrom(ReflectedType)) {
+                return UnityEngine.ScriptableObject.CreateInstance(ReflectedType);
+            }
+#endif
+
+            // Strings don't have default constructors but also fail when run
+            // through FormatterSerivces.GetSafeUninitializedObject
+            if (typeof(string) == ReflectedType) {
+                return string.Empty;
+            }
+
+            if (HasDefaultConstructor == false) {
+#if !UNITY_EDITOR && (UNITY_WEBPLAYER || UNITY_WP8 || UNITY_METRO)
+                throw new InvalidOperationException("The selected Unity platform requires " +
+                    ReflectedType.FullName + " to have a default constructor. Please add one.");
+#else
+                return System.Runtime.Serialization.FormatterServices.GetSafeUninitializedObject(ReflectedType);
+#endif
+            }
+
+            if (ReflectedType.Resolve().IsArray) {
+                // we have to start with a size zero array otherwise it will have
+                // invalid data inside of it
+                return Array.CreateInstance(ReflectedType.GetElementType(), 0);
+            }
+
+            try {
+#if (!UNITY_EDITOR && ((UNITY_METRO) || (UNITY_PS4)))
+                // In WinRT/WinStore & PS4 builds, Activator.CreateInstance(..., true)
+                // is broken
+                return Activator.CreateInstance(ReflectedType);
+#else
+                return Activator.CreateInstance(ReflectedType, /*nonPublic:*/ true);
+#endif
+            }
+#if (!UNITY_EDITOR && (UNITY_METRO)) == false
+            catch (MissingMethodException e) {
+                throw new InvalidOperationException("Unable to create instance of " + ReflectedType + "; there is no default constructor", e);
+            }
+#endif
+            catch (TargetInvocationException e) {
+                throw new InvalidOperationException("Constructor of " + ReflectedType + " threw an exception when creating an instance", e);
+            }
+            catch (MemberAccessException e) {
+                throw new InvalidOperationException("Unable to access constructor of " + ReflectedType, e);
+            }
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Reflection/fsMetaType.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Reflection/fsMetaType.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8dda7fa68f01f0e428c6d8090ae72532
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Reflection/fsReflectionUtility.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Reflection/fsReflectionUtility.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+#if !UNITY_EDITOR && UNITY_WSA
+// For System.Reflection.TypeExtensions
+using System.Reflection;
+#endif
+
+namespace FullSerializer.Internal {
+    public static class fsReflectionUtility {
+        /// <summary>
+        /// Searches for a particular implementation of the given interface type
+        /// inside of the type. This is particularly useful if the interface type
+        /// is an open type, ie, typeof(IFace{}), because this method will then
+        /// return IFace{} but with appropriate type parameters inserted.
+        /// </summary>
+        /// <param name="type">The base type to search for interface</param>
+        /// <param name="interfaceType">
+        /// The interface type to search for. Can be an open generic type.
+        /// </param>
+        /// <returns>
+        /// The actual interface type that the type contains, or null if there is
+        /// no implementation of the given interfaceType on type.
+        /// </returns>
+        public static Type GetInterface(Type type, Type interfaceType) {
+            if (interfaceType.Resolve().IsGenericType &&
+                interfaceType.Resolve().IsGenericTypeDefinition == false) {
+                throw new ArgumentException("GetInterface requires that if the interface " +
+                    "type is generic, then it must be the generic type definition, not a " +
+                    "specific generic type instantiation");
+            };
+
+            while (type != null) {
+                foreach (var iface in type.GetInterfaces()) {
+                    if (iface.Resolve().IsGenericType) {
+                        if (interfaceType == iface.GetGenericTypeDefinition()) {
+                            return iface;
+                        }
+                    }
+                    else if (interfaceType == iface) {
+                        return iface;
+                    }
+                }
+
+                type = type.Resolve().BaseType;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Reflection/fsReflectionUtility.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Reflection/fsReflectionUtility.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b2fe4e0d816d15145b26bd01d34c8b47
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/Reflection/fsTypeCache.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/Reflection/fsTypeCache.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace FullSerializer.Internal {
+    /// <summary>
+    /// Caches type name to type lookups. Type lookups occur in all loaded
+    /// assemblies.
+    /// </summary>
+    public static class fsTypeCache {
+        /// <summary>
+        /// Cache from fully qualified type name to type instances.
+        /// </summary>
+        // TODO: verify that type names will be unique
+        private static Dictionary<string, Type> _cachedTypes = new Dictionary<string, Type>();
+
+        /// <summary>
+        /// Assemblies indexed by their name.
+        /// </summary>
+        private static Dictionary<string, Assembly> _assembliesByName;
+
+        /// <summary>
+        /// A list of assemblies, by index.
+        /// </summary>
+        private static List<Assembly> _assembliesByIndex;
+
+        static fsTypeCache() {
+            lock (typeof(fsTypeCache)) {
+                // Setup assembly references so searching and the like resolves
+                // correctly.
+                _assembliesByName = new Dictionary<string, Assembly>();
+                _assembliesByIndex = new List<Assembly>();
+
+#if (!UNITY_EDITOR && UNITY_METRO && !ENABLE_IL2CPP) // no AppDomain on WinRT
+                var assembly = typeof(object).GetTypeInfo().Assembly;
+                _assembliesByName[assembly.FullName] = assembly;
+                _assembliesByIndex.Add(assembly);
+#else
+                foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()) {
+                    _assembliesByName[assembly.FullName] = assembly;
+                    _assembliesByIndex.Add(assembly);
+                }
+#endif
+                _cachedTypes = new Dictionary<string, Type>();
+
+#if !(UNITY_WP8  || UNITY_METRO) // AssemblyLoad events are not supported on these platforms
+                AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoaded;
+#endif
+            }
+        }
+
+#if !(UNITY_WP8 || UNITY_METRO) // AssemblyLoad events are not supported on these platforms
+        private static void OnAssemblyLoaded(object sender, AssemblyLoadEventArgs args) {
+            lock (typeof(fsTypeCache)) {
+                _assembliesByName[args.LoadedAssembly.FullName] = args.LoadedAssembly;
+                _assembliesByIndex.Add(args.LoadedAssembly);
+
+                _cachedTypes = new Dictionary<string, Type>();
+            }
+        }
+#endif
+
+        /// <summary>
+        /// Does a direct lookup for the given type, ie, goes directly to the
+        /// assembly identified by assembly name and finds it there.
+        /// </summary>
+        /// <param name="assemblyName">The assembly to find the type in.</param>
+        /// <param name="typeName">The name of the type.</param>
+        /// <param name="type">The found type.</param>
+        /// <returns>True if the type was found, false otherwise.</returns>
+        private static bool TryDirectTypeLookup(string assemblyName, string typeName, out Type type) {
+            if (assemblyName != null) {
+                Assembly assembly;
+                if (_assembliesByName.TryGetValue(assemblyName, out assembly)) {
+                    type = assembly.GetType(typeName, /*throwOnError:*/ false);
+                    return type != null;
+                }
+            }
+
+            type = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to do an indirect type lookup by scanning through every loaded
+        /// assembly until the type is found in one of them.
+        /// </summary>
+        /// <param name="typeName">The name of the type.</param>
+        /// <param name="type">The found type.</param>
+        /// <returns>True if the type was found, false otherwise.</returns>
+        private static bool TryIndirectTypeLookup(string typeName, out Type type) {
+            // There used to be a foreach loop through the value keys of the
+            // _assembliesByName dictionary. However, during that loop assembly
+            // loads could occur, causing an OutOfSync exception. To resolve
+            // that, we just iterate through the assemblies by index.
+
+            int i = 0;
+            while (i < _assembliesByIndex.Count) {
+                Assembly assembly = _assembliesByIndex[i];
+
+                // try GetType; should be fast
+                type = assembly.GetType(typeName);
+                if (type != null) {
+                    return true;
+                }
+                ++i;
+            }
+
+            i = 0;
+            // This code here is slow and is just here as a fallback
+            while (i < _assembliesByIndex.Count) {
+                Assembly assembly = _assembliesByIndex[i];
+
+                // private type or similar; go through the slow path and check
+                // every type's full name
+                foreach (var foundType in assembly.GetTypes()) {
+                    if (foundType.FullName == typeName) {
+                        type = foundType.GetType();
+                        return true;
+                    }
+                }
+                ++i;
+            }
+
+            type = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Removes any cached type lookup results.
+        /// </summary>
+        public static void Reset() {
+            _cachedTypes = new Dictionary<string, Type>();
+        }
+
+        /// <summary>
+        /// Find a type with the given name. An exception is thrown if no type
+        /// with the given name can be found. This method searches all currently
+        /// loaded assemblies for the given type. If the type cannot be found,
+        /// then null will be returned.
+        /// </summary>
+        /// <param name="name">The fully qualified name of the type.</param>
+        public static Type GetType(string name) {
+            return GetType(name, null);
+        }
+
+        /// <summary>
+        /// Find a type with the given name. An exception is thrown if no type
+        /// with the given name can be found. This method searches all currently
+        /// loaded assemblies for the given type. If the type cannot be found,
+        /// then null will be returned.
+        /// </summary>
+        /// <param name="name">The fully qualified name of the type.</param>
+        /// <param name="assemblyHint">
+        /// A hint for the assembly to start the search with. Use null if
+        /// unknown.
+        /// </param>
+        public static Type GetType(string name, string assemblyHint) {
+            if (string.IsNullOrEmpty(name)) {
+                return null;
+            }
+
+            lock (typeof(fsTypeCache)) {
+                Type type;
+                if (_cachedTypes.TryGetValue(name, out type) == false) {
+                    // if both the direct and indirect type lookups fail, then
+                    // throw an exception
+                    if (TryDirectTypeLookup(assemblyHint, name, out type) == false &&
+                        TryIndirectTypeLookup(name, out type) == false) {
+                    }
+
+                    _cachedTypes[name] = type;
+                }
+
+                return type;
+            }
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/Reflection/fsTypeCache.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/Reflection/fsTypeCache.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 45c4a046c8137494c9fe68a832aa751d
+timeCreated: 1455068576
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsBaseConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsBaseConverter.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FullSerializer.Internal;
+
+namespace FullSerializer {
+    /// <summary>
+    /// The serialization converter allows for customization of the serialization
+    /// process.
+    /// </summary>
+    /// <remarks>
+    /// You do not want to derive from this class - there is no way to actually
+    /// use it within the serializer.. Instead, derive from either fsConverter or
+    /// fsDirectConverter
+    /// </remarks>
+    public abstract class fsBaseConverter {
+        /// <summary>
+        /// The serializer that was owns this converter.
+        /// </summary>
+        public fsSerializer Serializer;
+
+        /// <summary>
+        /// Construct an object instance that will be passed to TryDeserialize.
+        /// This should **not** deserialize the object.
+        /// </summary>
+        /// <param name="data">The data the object was serialized with.</param>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <returns>An object instance</returns>
+        public virtual object CreateInstance(fsData data, Type storageType) {
+            if (RequestCycleSupport(storageType)) {
+                throw new InvalidOperationException("Please override CreateInstance for " +
+                    GetType().FullName + "; the object graph for " + storageType +
+                    " can contain potentially contain cycles, so separated instance creation " +
+                    "is needed");
+            }
+
+            return storageType;
+        }
+
+        /// <summary>
+        /// If true, then the serializer will support cyclic references with the
+        /// given converted type.
+        /// </summary>
+        /// <param name="storageType">
+        /// The field/property type that is currently storing the object that is
+        /// being serialized.
+        /// </param>
+        public virtual bool RequestCycleSupport(Type storageType) {
+            if (storageType == typeof(string)) return false;
+
+            return storageType.Resolve().IsClass || storageType.Resolve().IsInterface;
+        }
+
+        /// <summary>
+        /// If true, then the serializer will include inheritance data for the
+        /// given converter.
+        /// </summary>
+        /// <param name="storageType">
+        /// The field/property type that is currently storing the object that is
+        /// being serialized.
+        /// </param>
+        public virtual bool RequestInheritanceSupport(Type storageType) {
+            return storageType.Resolve().IsSealed == false;
+        }
+
+        /// <summary>
+        /// Serialize the actual object into the given data storage.
+        /// </summary>
+        /// <param name="instance">
+        /// The object instance to serialize. This will never be null.
+        /// </param>
+        /// <param name="serialized">The serialized state.</param>
+        /// <param name="storageType">
+        /// The field/property type that is storing this instance.
+        /// </param>
+        /// <returns>If serialization was successful.</returns>
+        public abstract fsResult TrySerialize(object instance, out fsData serialized, Type storageType);
+
+        /// <summary>
+        /// Deserialize data into the object instance.
+        /// </summary>
+        /// <param name="data">Serialization data to deserialize from.</param>
+        /// <param name="instance">
+        /// The object instance to deserialize into.
+        /// </param>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <returns>
+        /// True if serialization was successful, false otherwise.
+        /// </returns>
+        public abstract fsResult TryDeserialize(fsData data, ref object instance, Type storageType);
+
+        protected fsResult FailExpectedType(fsData data, params fsDataType[] types) {
+            return fsResult.Fail(GetType().Name + " expected one of " +
+                string.Join(", ", types.Select(t => t.ToString()).ToArray()) +
+                " but got " + data.Type + " in " + data);
+        }
+
+        protected fsResult CheckType(fsData data, fsDataType type) {
+            if (data.Type != type) {
+                return fsResult.Fail(GetType().Name + " expected " + type + " but got " + data.Type + " in " + data);
+            }
+            return fsResult.Success;
+        }
+
+        protected fsResult CheckKey(fsData data, string key, out fsData subitem) {
+            return CheckKey(data.AsDictionary, key, out subitem);
+        }
+
+        protected fsResult CheckKey(Dictionary<string, fsData> data, string key, out fsData subitem) {
+            if (data.TryGetValue(key, out subitem) == false) {
+                return fsResult.Fail(GetType().Name + " requires a <" + key + "> key in the data " + data);
+            }
+            return fsResult.Success;
+        }
+
+        protected fsResult SerializeMember<T>(Dictionary<string, fsData> data, Type overrideConverterType, string name, T value) {
+            fsData memberData;
+            var result = Serializer.TrySerialize(typeof(T), overrideConverterType, value, out memberData);
+            if (result.Succeeded) data[name] = memberData;
+            return result;
+        }
+
+        protected fsResult DeserializeMember<T>(Dictionary<string, fsData> data, Type overrideConverterType, string name, out T value) {
+            fsData memberData;
+            if (data.TryGetValue(name, out memberData) == false) {
+                value = default(T);
+                return fsResult.Fail("Unable to find member \"" + name + "\"");
+            }
+
+            object storage = null;
+            var result = Serializer.TryDeserialize(memberData, typeof(T), overrideConverterType, ref storage);
+            value = (T)storage;
+            return result;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsBaseConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsBaseConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 183143ebe6dd0124aac0741ff70e1fd2
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsConfig.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsConfig.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Reflection;
+
+namespace FullSerializer {
+    // Global configuration options.
+    public static class fsGlobalConfig {
+        /// <summary>
+        /// Should deserialization be case sensitive? If this is false and the
+        /// JSON has multiple members with the same keys only separated by case,
+        /// then this results in undefined behavior.
+        /// </summary>
+        public static bool IsCaseSensitive = true;
+
+        /// <summary>
+        /// If exceptions are allowed internally, then additional date formats
+        /// can be deserialized. Note that the Full Serializer public API will
+        /// *not* throw exceptions with this enabled; errors will still be
+        /// returned in a fsResult instance.
+        /// </summary>
+        public static bool AllowInternalExceptions = true;
+
+        /// <summary>
+        /// This string will be used to prefix fields used internally by
+        /// FullSerializer.
+        /// </summary>
+        public static string InternalFieldPrefix = "$";
+    }
+
+    /// <summary>
+    /// Enables some top-level customization of Full Serializer.
+    /// </summary>
+    public class fsConfig {
+        /// <summary>
+        /// The attributes that will force a field or property to be serialized.
+        /// </summary>
+        public Type[] SerializeAttributes = {
+#if !NO_UNITY
+            typeof(UnityEngine.SerializeField),
+#endif
+            typeof(fsPropertyAttribute)
+        };
+
+        /// <summary>
+        /// The attributes that will force a field or property to *not* be
+        /// serialized.
+        /// </summary>
+        public Type[] IgnoreSerializeAttributes = { typeof(NonSerializedAttribute), typeof(fsIgnoreAttribute) };
+
+        /// <summary>
+        /// The attributes on a type that will force any fields or properties
+		/// of that type to *not* be serialized.
+        /// </summary>
+        public Type[] IgnoreSerializeTypeAttributes = { typeof(fsIgnoreAttribute) };
+
+        /// <summary>
+        /// The default member serialization.
+        /// </summary>
+        public fsMemberSerialization DefaultMemberSerialization = fsMemberSerialization.Default;
+
+        /// <summary>
+        /// Convert a C# field/property name into the key used for the JSON
+        /// object. For example, you could force all JSON names to lowercase
+        /// with:
+        ///
+        /// fsConfig.GetJsonNameFromMemberName = (name, info) =&gt;
+        /// name.ToLower();
+        ///
+        /// This will only be used when the name is not explicitly specified with
+        /// fsProperty.
+        /// </summary>
+        public Func<string, MemberInfo, string> GetJsonNameFromMemberName = (name, info) => name;
+
+        /// <summary>
+        /// If false, then *all* property serialization support will be disabled
+        /// - even properties explicitly annotated with fsProperty or any other
+        /// opt-in annotation.
+        ///
+        /// Setting this to false means that SerializeNonAutoProperties and
+        /// SerializeNonPublicSetProperties will be completely ignored.
+        /// </summary>
+        public bool EnablePropertySerialization = true;
+
+        /// <summary>
+        /// Should the default serialization behaviour include non-auto
+        /// properties?
+        /// </summary>
+        public bool SerializeNonAutoProperties = false;
+
+        /// <summary>
+        /// Should the default serialization behaviour include properties with
+        /// non-public setters?
+        /// </summary>
+        public bool SerializeNonPublicSetProperties = true;
+
+        /// <summary>
+        /// If not null, this string format will be used for DateTime instead of
+        /// the default one.
+        /// </summary>
+        public string CustomDateTimeFormatString = null;
+
+        /// <summary>
+        /// Int64 and UInt64 will be serialized and deserialized as string for
+        /// compatibility
+        /// </summary>
+        public bool Serialize64BitIntegerAsString = false;
+
+        /// <summary>
+        /// Enums are serialized using their names by default. Setting this to
+        /// true will serialize them as integers instead.
+        /// </summary>
+        public bool SerializeEnumsAsInteger = false;
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsConfig.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsConfig.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b59903dfb496d004d8f08677c027e7f6
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsContext.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsContext.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FullSerializer {
+    /// <summary>
+    /// fsContext stores global metadata that can be used to customize how
+    /// fsConverters operate during serialization.
+    /// </summary>
+    public sealed class fsContext {
+        /// <summary>
+        /// All of the context objects.
+        /// </summary>
+        private readonly Dictionary<Type, object> _contextObjects = new Dictionary<Type, object>();
+
+        /// <summary>
+        /// Removes all context objects from the context.
+        /// </summary>
+        public void Reset() {
+            _contextObjects.Clear();
+        }
+
+        /// <summary>
+        /// Sets the context object for the given type with the given value.
+        /// </summary>
+        public void Set<T>(T obj) {
+            _contextObjects[typeof(T)] = obj;
+        }
+
+        /// <summary>
+        /// Returns true if there is a context object for the given type.
+        /// </summary>
+        public bool Has<T>() {
+            return _contextObjects.ContainsKey(typeof(T));
+        }
+
+        /// <summary>
+        /// Fetches the context object for the given type.
+        /// </summary>
+        public T Get<T>() {
+            object val;
+            if (_contextObjects.TryGetValue(typeof(T), out val)) {
+                return (T)val;
+            }
+            throw new InvalidOperationException("There is no context object of type " + typeof(T));
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsContext.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsContext.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9dbf6cf73c266b14eba03d329717a810
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsConverter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace FullSerializer {
+    /// <summary>
+    /// The serialization converter allows for customization of the serialization
+    /// process.
+    /// </summary>
+    public abstract class fsConverter : fsBaseConverter {
+        /// <summary>
+        /// Can this converter serialize and deserialize the given object type?
+        /// </summary>
+        /// <param name="type">The given object type.</param>
+        /// <returns>
+        /// True if the converter can serialize it, false otherwise.
+        /// </returns>
+        public abstract bool CanProcess(Type type);
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 77ed27c3d6b79c044ad5c52b7832d379
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsConverterRegistrar.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsConverterRegistrar.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using FullSerializer.Internal;
+
+namespace FullSerializer {
+    /// <summary>
+    /// This class allows arbitrary code to easily register global converters. To
+    /// add a converter, simply declare a new field called "Register_*" that
+    /// stores the type of converter you would like to add. Alternatively, you
+    /// can do the same with a method called "Register_*"; just add the converter
+    /// type to the `Converters` list.
+    /// </summary>
+    public partial class fsConverterRegistrar {
+        static fsConverterRegistrar() {
+            Converters = new List<Type>();
+
+            foreach (var field in typeof(fsConverterRegistrar).GetDeclaredFields()) {
+                if (field.Name.StartsWith("Register_"))
+                    Converters.Add(field.FieldType);
+            }
+
+            foreach (var method in typeof(fsConverterRegistrar).GetDeclaredMethods()) {
+                if (method.Name.StartsWith("Register_"))
+                    method.Invoke(null, null);
+            }
+
+            // Make sure we do not use any AOT Models which are out of date.
+            var finalResult = new List<Type>(Converters);
+            foreach (Type t in Converters) {
+                object instance = null;
+                try {
+                    instance = Activator.CreateInstance(t);
+                } catch (Exception) {}
+
+                var aotConverter = instance as fsIAotConverter;
+                if (aotConverter != null) {
+                    var modelMetaType = fsMetaType.Get(new fsConfig(), aotConverter.ModelType);
+                    if (fsAotCompilationManager.IsAotModelUpToDate(modelMetaType, aotConverter) == false) {
+                        finalResult.Remove(t);
+                    }
+                }
+            }
+            Converters = finalResult;
+        }
+
+        public static List<Type> Converters;
+
+        // Example field registration:
+        //public static AnimationCurve_DirectConverter Register_AnimationCurve_DirectConverter;
+
+        // Example method registration:
+        //public static void Register_AnimationCurve_DirectConverter() {
+        //    Converters.Add(typeof(AnimationCurve_DirectConverter));
+        //}
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsConverterRegistrar.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsConverterRegistrar.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: fa1f5994b782ae24db0ec14460b60dc4
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsData.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsData.cs
@@ -1,0 +1,403 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace FullSerializer {
+    /// <summary>
+    /// The actual type that a JsonData instance can store.
+    /// </summary>
+    public enum fsDataType {
+        Array,
+        Object,
+        Double,
+        Int64,
+        Boolean,
+        String,
+        Null
+    }
+
+    /// <summary>
+    /// A union type that stores a serialized value. The stored type can be one
+    /// of six different
+    /// types: null, boolean, double, Int64, string, Dictionary, or List.
+    /// </summary>
+    public sealed class fsData {
+        /// <summary>
+        /// The raw value that this serialized data stores. It can be one of six
+        /// different types; a boolean, a double, Int64, a string, a Dictionary,
+        /// or a List.
+        /// </summary>
+        private object _value;
+
+        #region Constructors
+        /// <summary>
+        /// Creates a fsData instance that holds null.
+        /// </summary>
+        public fsData() {
+            _value = null;
+        }
+
+        /// <summary>
+        /// Creates a fsData instance that holds a boolean.
+        /// </summary>
+        public fsData(bool boolean) {
+            _value = boolean;
+        }
+
+        /// <summary>
+        /// Creates a fsData instance that holds a double.
+        /// </summary>
+        public fsData(double f) {
+            _value = f;
+        }
+
+        /// <summary>
+        /// Creates a new fsData instance that holds an integer.
+        /// </summary>
+        public fsData(Int64 i) {
+            _value = i;
+        }
+
+        /// <summary>
+        /// Creates a fsData instance that holds a string.
+        /// </summary>
+        public fsData(string str) {
+            _value = str;
+        }
+
+        /// <summary>
+        /// Creates a fsData instance that holds a dictionary of values.
+        /// </summary>
+        public fsData(Dictionary<string, fsData> dict) {
+            _value = dict;
+        }
+
+        /// <summary>
+        /// Creates a fsData instance that holds a list of values.
+        /// </summary>
+        public fsData(List<fsData> list) {
+            _value = list;
+        }
+
+        /// <summary>
+        /// Helper method to create a fsData instance that holds a dictionary.
+        /// </summary>
+        public static fsData CreateDictionary() {
+            return new fsData(new Dictionary<string, fsData>(
+                fsGlobalConfig.IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Helper method to create a fsData instance that holds a list.
+        /// </summary>
+        public static fsData CreateList() {
+            return new fsData(new List<fsData>());
+        }
+
+        /// <summary>
+        /// Helper method to create a fsData instance that holds a list with the
+        /// initial capacity.
+        /// </summary>
+        public static fsData CreateList(int capacity) {
+            return new fsData(new List<fsData>(capacity));
+        }
+
+        public readonly static fsData True = new fsData(true);
+        public readonly static fsData False = new fsData(false);
+        public readonly static fsData Null = new fsData();
+        #endregion Constructors
+
+        #region Internal Helper Methods
+        /// <summary>
+        /// Transforms the internal fsData instance into a dictionary.
+        /// </summary>
+        internal void BecomeDictionary() {
+            _value = new Dictionary<string, fsData>();
+        }
+
+        /// <summary>
+        /// Returns a shallow clone of this data instance.
+        /// </summary>
+        internal fsData Clone() {
+            var clone = new fsData();
+            clone._value = _value;
+            return clone;
+        }
+        #endregion Internal Helper Methods
+
+        #region Casting Predicates
+        public fsDataType Type {
+            get {
+                if (_value == null) return fsDataType.Null;
+                if (_value is double) return fsDataType.Double;
+                if (_value is Int64) return fsDataType.Int64;
+                if (_value is bool) return fsDataType.Boolean;
+                if (_value is string) return fsDataType.String;
+                if (_value is Dictionary<string, fsData>) return fsDataType.Object;
+                if (_value is List<fsData>) return fsDataType.Array;
+
+                throw new InvalidOperationException("unknown JSON data type");
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this fsData instance maps back to null.
+        /// </summary>
+        public bool IsNull {
+            get {
+                return _value == null;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this fsData instance maps back to a double.
+        /// </summary>
+        public bool IsDouble {
+            get {
+                return _value is double;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this fsData instance maps back to an Int64.
+        /// </summary>
+        public bool IsInt64 {
+            get {
+                return _value is Int64;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this fsData instance maps back to a boolean.
+        /// </summary>
+        public bool IsBool {
+            get {
+                return _value is bool;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this fsData instance maps back to a string.
+        /// </summary>
+        public bool IsString {
+            get {
+                return _value is string;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this fsData instance maps back to a Dictionary.
+        /// </summary>
+        public bool IsDictionary {
+            get {
+                return _value is Dictionary<string, fsData>;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this fsData instance maps back to a List.
+        /// </summary>
+        public bool IsList {
+            get {
+                return _value is List<fsData>;
+            }
+        }
+        #endregion Casting Predicates
+
+        #region Casts
+        /// <summary>
+        /// Casts this fsData to a double. Throws an exception if it is not a
+        /// double.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public double AsDouble {
+            get {
+                return Cast<double>();
+            }
+        }
+
+        /// <summary>
+        /// Casts this fsData to an Int64. Throws an exception if it is not an
+        /// Int64.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public Int64 AsInt64 {
+            get {
+                return Cast<Int64>();
+            }
+        }
+
+        /// <summary>
+        /// Casts this fsData to a boolean. Throws an exception if it is not a
+        /// boolean.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public bool AsBool {
+            get {
+                return Cast<bool>();
+            }
+        }
+
+        /// <summary>
+        /// Casts this fsData to a string. Throws an exception if it is not a
+        /// string.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public string AsString {
+            get {
+                return Cast<string>();
+            }
+        }
+
+        /// <summary>
+        /// Casts this fsData to a Dictionary. Throws an exception if it is not a
+        /// Dictionary.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public Dictionary<string, fsData> AsDictionary {
+            get {
+                return Cast<Dictionary<string, fsData>>();
+            }
+        }
+
+        /// <summary>
+        /// Casts this fsData to a List. Throws an exception if it is not a List.
+        /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public List<fsData> AsList {
+            get {
+                return Cast<List<fsData>>();
+            }
+        }
+
+        /// <summary>
+        /// Internal helper method to cast the underlying storage to the given
+        /// type or throw a pretty printed exception on failure.
+        /// </summary>
+        private T Cast<T>() {
+            if (_value is T) {
+                return (T)_value;
+            }
+
+            throw new InvalidCastException("Unable to cast <" + this + "> (with type = " +
+                _value.GetType() + ") to type " + typeof(T));
+        }
+        #endregion Casts
+
+        #region ToString Implementation
+        public override string ToString() {
+            return fsJsonPrinter.CompressedJson(this);
+        }
+        #endregion ToString Implementation
+
+        #region Equality Comparisons
+        /// <summary>
+        /// Determines whether the specified object is equal to the current
+        /// object.
+        /// </summary>
+        public override bool Equals(object obj) {
+            return Equals(obj as fsData);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current
+        /// object.
+        /// </summary>
+        public bool Equals(fsData other) {
+            if (other == null || Type != other.Type) {
+                return false;
+            }
+
+            switch (Type) {
+                case fsDataType.Null:
+                    return true;
+
+                case fsDataType.Double:
+                    return AsDouble == other.AsDouble || Math.Abs(AsDouble - other.AsDouble) < double.Epsilon;
+
+                case fsDataType.Int64:
+                    return AsInt64 == other.AsInt64;
+
+                case fsDataType.Boolean:
+                    return AsBool == other.AsBool;
+
+                case fsDataType.String:
+                    return AsString == other.AsString;
+
+                case fsDataType.Array:
+                    var thisList = AsList;
+                    var otherList = other.AsList;
+
+                    if (thisList.Count != otherList.Count) return false;
+
+                    for (int i = 0; i < thisList.Count; ++i) {
+                        if (thisList[i].Equals(otherList[i]) == false) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+
+                case fsDataType.Object:
+                    var thisDict = AsDictionary;
+                    var otherDict = other.AsDictionary;
+
+                    if (thisDict.Count != otherDict.Count) return false;
+
+                    foreach (string key in thisDict.Keys) {
+                        if (otherDict.ContainsKey(key) == false) {
+                            return false;
+                        }
+
+                        if (thisDict[key].Equals(otherDict[key]) == false) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+            }
+
+            throw new Exception("Unknown data type");
+        }
+
+        /// <summary>
+        /// Returns true iff a == b.
+        /// </summary>
+        public static bool operator ==(fsData a, fsData b) {
+            // If both are null, or both are same instance, return true.
+            if (ReferenceEquals(a, b)) {
+                return true;
+            }
+
+            // If one is null, but not both, return false.
+            if (((object)a == null) || ((object)b == null)) {
+                return false;
+            }
+
+            if (a.IsDouble && b.IsDouble) {
+                return Math.Abs(a.AsDouble - b.AsDouble) < double.Epsilon;
+            }
+
+            return a.Equals(b);
+        }
+
+        /// <summary>
+        /// Returns true iff a != b.
+        /// </summary>
+        public static bool operator !=(fsData a, fsData b) {
+            return !(a == b);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms
+        /// and data structures like a hash table.
+        /// </returns>
+        public override int GetHashCode() {
+            return _value.GetHashCode();
+        }
+        #endregion Equality Comparisons
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsData.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsData.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5cc8656e43d482941b2b95d443c36174
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsDirectConverter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsDirectConverter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FullSerializer {
+    /// <summary>
+    /// The direct converter is similar to a regular converter, except that it
+    /// targets specifically only one type. This means that it can be used
+    /// without performance impact when discovering converters. It is strongly
+    /// recommended that you derive from fsDirectConverter{TModel}.
+    /// </summary>
+    /// <remarks>
+    /// Due to the way that direct converters operate, inheritance is *not*
+    /// supported. Direct converters will only be used with the exact ModelType
+    /// object.
+    /// </remarks>
+    public abstract class fsDirectConverter : fsBaseConverter {
+        public abstract Type ModelType { get; }
+    }
+
+    public abstract class fsDirectConverter<TModel> : fsDirectConverter {
+        public override Type ModelType { get { return typeof(TModel); } }
+
+        public sealed override fsResult TrySerialize(object instance, out fsData serialized, Type storageType) {
+            var serializedDictionary = new Dictionary<string, fsData>();
+            var result = DoSerialize((TModel)instance, serializedDictionary);
+            serialized = new fsData(serializedDictionary);
+            return result;
+        }
+
+        public sealed override fsResult TryDeserialize(fsData data, ref object instance, Type storageType) {
+            var result = fsResult.Success;
+            if ((result += CheckType(data, fsDataType.Object)).Failed) return result;
+
+            var obj = (TModel)instance;
+            result += DoDeserialize(data.AsDictionary, ref obj);
+            instance = obj;
+            return result;
+        }
+
+        protected abstract fsResult DoSerialize(TModel model, Dictionary<string, fsData> serialized);
+        protected abstract fsResult DoDeserialize(Dictionary<string, fsData> data, ref TModel model);
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsDirectConverter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsDirectConverter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 01d299a12e9acb74ea4725bd6158642a
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsExceptions.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsExceptions.cs
@@ -1,0 +1,17 @@
+﻿// note: This file contains exceptions used by FullSerializer. Exceptions are
+//       never used at runtime in FullSerializer; they are only used when
+//       validating annotations and code-based models.
+
+using System;
+
+namespace FullSerializer {
+    public sealed class fsMissingVersionConstructorException : Exception {
+        public fsMissingVersionConstructorException(Type versionedType, Type constructorType) :
+            base(versionedType + " is missing a constructor for previous model type " + constructorType) { }
+    }
+
+    public sealed class fsDuplicateVersionNameException : Exception {
+        public fsDuplicateVersionNameException(Type typeA, Type typeB, string version) :
+            base(typeA + " and " + typeB + " have the same version string (" + version + "); please change one of them.") { }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsExceptions.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsExceptions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 38269c00973f4f64db007f13af5acbf4
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsISerializationCallbacks.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsISerializationCallbacks.cs
@@ -1,0 +1,106 @@
+using System;
+#if !NO_UNITY
+using UnityEngine;
+#endif
+
+#if !UNITY_EDITOR && UNITY_WSA
+// For System.Reflection.TypeExtensions
+using System.Reflection;
+#endif
+
+namespace FullSerializer {
+    /// <summary>
+    /// Extend this interface on your type to receive notifications about
+    /// serialization/deserialization events. If you don't have access to the
+    /// type itself, then you can write an fsObjectProcessor instead.
+    /// </summary>
+    public interface fsISerializationCallbacks {
+        /// <summary>
+        /// Called before serialization.
+        /// </summary>
+        void OnBeforeSerialize(Type storageType);
+
+        /// <summary>
+        /// Called after serialization.
+        /// </summary>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <param name="data">The data that was serialized.</param>
+        void OnAfterSerialize(Type storageType, ref fsData data);
+
+        /// <summary>
+        /// Called before deserialization.
+        /// </summary>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <param name="data">
+        /// The data that will be used for deserialization.
+        /// </param>
+        void OnBeforeDeserialize(Type storageType, ref fsData data);
+
+        /// <summary>
+        /// Called after deserialization.
+        /// </summary>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <param name="instance">The type of the instance.</param>
+        void OnAfterDeserialize(Type storageType);
+    }
+}
+
+namespace FullSerializer.Internal {
+    public class fsSerializationCallbackProcessor : fsObjectProcessor {
+        public override bool CanProcess(Type type) {
+            return typeof(fsISerializationCallbacks).IsAssignableFrom(type);
+        }
+
+        public override void OnBeforeSerialize(Type storageType, object instance) {
+            // Don't call the callback on null instances.
+            if (instance == null) return;
+            ((fsISerializationCallbacks)instance).OnBeforeSerialize(storageType);
+        }
+
+        public override void OnAfterSerialize(Type storageType, object instance, ref fsData data) {
+            // Don't call the callback on null instances.
+            if (instance == null) return;
+            ((fsISerializationCallbacks)instance).OnAfterSerialize(storageType, ref data);
+        }
+
+        public override void OnBeforeDeserializeAfterInstanceCreation(Type storageType, object instance, ref fsData data) {
+            if (instance is fsISerializationCallbacks == false) {
+                throw new InvalidCastException("Please ensure the converter for " + storageType + " actually returns an instance of it, not an instance of " + instance.GetType());
+            }
+
+            ((fsISerializationCallbacks)instance).OnBeforeDeserialize(storageType, ref data);
+        }
+
+        public override void OnAfterDeserialize(Type storageType, object instance) {
+            // Don't call the callback on null instances.
+            if (instance == null) return;
+            ((fsISerializationCallbacks)instance).OnAfterDeserialize(storageType);
+        }
+    }
+
+#if !NO_UNITY
+    public class fsSerializationCallbackReceiverProcessor : fsObjectProcessor {
+        public override bool CanProcess(Type type) {
+            return typeof(ISerializationCallbackReceiver).IsAssignableFrom(type);
+        }
+
+        public override void OnBeforeSerialize(Type storageType, object instance) {
+            // Don't call the callback on null instances.
+            if (instance == null) return;
+            ((ISerializationCallbackReceiver)instance).OnBeforeSerialize();
+        }
+
+        public override void OnAfterDeserialize(Type storageType, object instance) {
+            // Don't call the callback on null instances.
+            if (instance == null) return;
+            ((ISerializationCallbackReceiver)instance).OnAfterDeserialize();
+        }
+    }
+#endif
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsISerializationCallbacks.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsISerializationCallbacks.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ff5a6a4a9df9cfc43b04b16bbc045902
+timeCreated: 1451205262
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsIgnoreAttribute.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsIgnoreAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace FullSerializer {
+    /// <summary>
+    /// The given property or field annotated with [JsonIgnore] will not be
+    /// serialized.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Struct)]
+    public sealed class fsIgnoreAttribute : Attribute {
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsIgnoreAttribute.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsIgnoreAttribute.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 040c5c9958137624c91fc44ec697d76f
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsJsonParser.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsJsonParser.cs
@@ -1,0 +1,509 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace FullSerializer {
+    // TODO: properly propagate warnings/etc for fsResult states
+
+    /// <summary>
+    /// A simple recursive descent parser for JSON.
+    /// </summary>
+    public class fsJsonParser {
+        private int _start;
+        private string _input;
+
+        private fsResult MakeFailure(string message) {
+            int start = Math.Max(0, _start - 20);
+            int length = Math.Min(50, _input.Length - start);
+
+            string error = "Error while parsing: " + message + "; context = <" +
+                _input.Substring(start, length) + ">";
+            return fsResult.Fail(error);
+        }
+
+        private bool TryMoveNext() {
+            if (_start < _input.Length) {
+                ++_start;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool HasValue() {
+            return HasValue(0);
+        }
+
+        private bool HasValue(int offset) {
+            return (_start + offset) >= 0 && (_start + offset) < _input.Length;
+        }
+
+        private char Character() {
+            return Character(0);
+        }
+
+        private char Character(int offset) {
+            return _input[_start + offset];
+        }
+
+        /// <summary>
+        /// Skips input such that Character() will return a non-whitespace
+        /// character
+        /// </summary>
+        private void SkipSpace() {
+            while (HasValue()) {
+                char c = Character();
+
+                // whitespace; fine to skip
+                if (char.IsWhiteSpace(c)) {
+                    TryMoveNext();
+                    continue;
+                }
+
+                // comment?
+                if (HasValue(1) && Character(0) == '/') {
+                    if (Character(1) == '/') {
+                        // skip the rest of the line
+                        while (HasValue() && Environment.NewLine.Contains("" + Character()) == false) {
+                            TryMoveNext();
+                        }
+                        continue;
+                    }
+                    else if (Character(1) == '*') {
+                        // skip to comment close
+                        TryMoveNext();
+                        TryMoveNext();
+                        while (HasValue(1)) {
+                            if (Character(0) == '*' && Character(1) == '/') {
+                                TryMoveNext();
+                                TryMoveNext();
+                                TryMoveNext();
+                                break;
+                            }
+                            else {
+                                TryMoveNext();
+                            }
+                        }
+                    }
+                    // let other checks to check fail
+                    continue;
+                }
+
+                break;
+            }
+        }
+
+        #region Escaping
+        private bool IsHex(char c) {
+            return ((c >= '0' && c <= '9') ||
+                     (c >= 'a' && c <= 'f') ||
+                     (c >= 'A' && c <= 'F'));
+        }
+
+        private uint ParseSingleChar(char c1, uint multipliyer) {
+            uint p1 = 0;
+            if (c1 >= '0' && c1 <= '9')
+                p1 = (uint)(c1 - '0') * multipliyer;
+            else if (c1 >= 'A' && c1 <= 'F')
+                p1 = (uint)((c1 - 'A') + 10) * multipliyer;
+            else if (c1 >= 'a' && c1 <= 'f')
+                p1 = (uint)((c1 - 'a') + 10) * multipliyer;
+            return p1;
+        }
+
+        private uint ParseUnicode(char c1, char c2, char c3, char c4) {
+            uint p1 = ParseSingleChar(c1, 0x1000);
+            uint p2 = ParseSingleChar(c2, 0x100);
+            uint p3 = ParseSingleChar(c3, 0x10);
+            uint p4 = ParseSingleChar(c4, 0x1);
+
+            return p1 + p2 + p3 + p4;
+        }
+
+        private fsResult TryUnescapeChar(out char escaped) {
+            // skip leading backslash '\'
+            TryMoveNext();
+            if (HasValue() == false) {
+                escaped = ' ';
+                return MakeFailure("Unexpected end of input after \\");
+            }
+
+            switch (Character()) {
+                case '\\': TryMoveNext(); escaped = '\\'; return fsResult.Success;
+                case '/': TryMoveNext(); escaped = '/'; return fsResult.Success;
+                case '"': TryMoveNext(); escaped = '\"'; return fsResult.Success;
+                case 'a': TryMoveNext(); escaped = '\a'; return fsResult.Success;
+                case 'b': TryMoveNext(); escaped = '\b'; return fsResult.Success;
+                case 'f': TryMoveNext(); escaped = '\f'; return fsResult.Success;
+                case 'n': TryMoveNext(); escaped = '\n'; return fsResult.Success;
+                case 'r': TryMoveNext(); escaped = '\r'; return fsResult.Success;
+                case 't': TryMoveNext(); escaped = '\t'; return fsResult.Success;
+                case '0': TryMoveNext(); escaped = '\0'; return fsResult.Success;
+                case 'u':
+                    TryMoveNext();
+                    if (IsHex(Character(0))
+                     && IsHex(Character(1))
+                     && IsHex(Character(2))
+                     && IsHex(Character(3))) {
+                        uint codePoint = ParseUnicode(Character(0), Character(1), Character(2), Character(3));
+
+                        TryMoveNext();
+                        TryMoveNext();
+                        TryMoveNext();
+                        TryMoveNext();
+
+                        escaped = (char)codePoint;
+                        return fsResult.Success;
+                    }
+
+                    // invalid escape sequence
+                    escaped = (char)0;
+                    return MakeFailure(
+                        string.Format("invalid escape sequence '\\u{0}{1}{2}{3}'\n",
+                            Character(0),
+                            Character(1),
+                            Character(2),
+                            Character(3)));
+                default:
+                    escaped = (char)0;
+                    return MakeFailure(string.Format("Invalid escape sequence \\{0}", Character()));
+            }
+        }
+        #endregion Escaping
+
+        private fsResult TryParseExact(string content) {
+            for (int i = 0; i < content.Length; ++i) {
+                if (Character() != content[i]) {
+                    return MakeFailure("Expected " + content[i]);
+                }
+
+                if (TryMoveNext() == false) {
+                    return MakeFailure("Unexpected end of content when parsing " + content);
+                }
+            }
+
+            return fsResult.Success;
+        }
+
+        private fsResult TryParseTrue(out fsData data) {
+            var fail = TryParseExact("true");
+
+            if (fail.Succeeded) {
+                data = new fsData(true);
+                return fsResult.Success;
+            }
+
+            data = null;
+            return fail;
+        }
+
+        private fsResult TryParseFalse(out fsData data) {
+            var fail = TryParseExact("false");
+
+            if (fail.Succeeded) {
+                data = new fsData(false);
+                return fsResult.Success;
+            }
+
+            data = null;
+            return fail;
+        }
+
+        private fsResult TryParseNull(out fsData data) {
+            var fail = TryParseExact("null");
+
+            if (fail.Succeeded) {
+                data = new fsData();
+                return fsResult.Success;
+            }
+
+            data = null;
+            return fail;
+        }
+
+        private bool IsSeparator(char c) {
+            return char.IsWhiteSpace(c) || c == ',' || c == '}' || c == ']';
+        }
+
+        /// <summary>
+        /// Parses numbers that follow the regular expression [-+](\d+|\d*\.\d*)
+        /// </summary>
+        private fsResult TryParseNumber(out fsData data) {
+            int start = _start;
+
+            // read until we get to a separator
+            while (
+                TryMoveNext() &&
+                (HasValue() && IsSeparator(Character()) == false)) {
+            }
+
+            // try to parse the value
+            string numberString = _input.Substring(start, _start - start);
+
+            // double -- includes a .
+            if (numberString.Contains(".") || numberString.Contains("e") || numberString.Contains("E") ||
+                numberString == "Infinity" || numberString == "-Infinity" || numberString == "NaN") {
+                double doubleValue;
+                if (double.TryParse(numberString, NumberStyles.Any, CultureInfo.InvariantCulture, out doubleValue) == false) {
+                    data = null;
+                    return MakeFailure("Bad double format with " + numberString);
+                }
+
+                data = new fsData(doubleValue);
+                return fsResult.Success;
+            }
+            else {
+                Int64 intValue;
+                if (Int64.TryParse(numberString, NumberStyles.Any, CultureInfo.InvariantCulture, out intValue) == false) {
+                    data = null;
+                    return MakeFailure("Bad Int64 format with " + numberString);
+                }
+
+                data = new fsData(intValue);
+                return fsResult.Success;
+            }
+        }
+
+        private readonly StringBuilder _cachedStringBuilder = new StringBuilder(256);
+        /// <summary>
+        /// Parses a string
+        /// </summary>
+        private fsResult TryParseString(out string str) {
+            _cachedStringBuilder.Length = 0;
+
+            // skip the first "
+            if (Character() != '"' || TryMoveNext() == false) {
+                str = string.Empty;
+                return MakeFailure("Expected initial \" when parsing a string");
+            }
+
+            // read until the next "
+            while (HasValue() && Character() != '\"') {
+                char c = Character();
+
+                // escape if necessary
+                if (c == '\\') {
+                    char unescaped;
+                    var fail = TryUnescapeChar(out unescaped);
+                    if (fail.Failed) {
+                        str = string.Empty;
+                        return fail;
+                    }
+
+                    _cachedStringBuilder.Append(unescaped);
+                }
+
+                // no escaping necessary
+                else {
+                    _cachedStringBuilder.Append(c);
+
+                    // get the next character
+                    if (TryMoveNext() == false) {
+                        str = string.Empty;
+                        return MakeFailure("Unexpected end of input when reading a string");
+                    }
+                }
+            }
+
+            // skip the first "
+            if (HasValue() == false || Character() != '"' || TryMoveNext() == false) {
+                str = string.Empty;
+                return MakeFailure("No closing \" when parsing a string");
+            }
+
+            str = _cachedStringBuilder.ToString();
+            return fsResult.Success;
+        }
+
+        /// <summary>
+        /// Parses an array
+        /// </summary>
+        private fsResult TryParseArray(out fsData arr) {
+            if (Character() != '[') {
+                arr = null;
+                return MakeFailure("Expected initial [ when parsing an array");
+            }
+
+            // skip '['
+            if (TryMoveNext() == false) {
+                arr = null;
+                return MakeFailure("Unexpected end of input when parsing an array");
+            }
+            SkipSpace();
+
+            var result = new List<fsData>();
+
+            while (HasValue() && Character() != ']') {
+                // parse the element
+                fsData element;
+                var fail = RunParse(out element);
+                if (fail.Failed) {
+                    arr = null;
+                    return fail;
+                }
+
+                result.Add(element);
+
+                // parse the comma
+                SkipSpace();
+                if (HasValue() && Character() == ',') {
+                    if (TryMoveNext() == false) break;
+                    SkipSpace();
+                }
+            }
+
+            // skip the final ]
+            if (HasValue() == false || Character() != ']' || TryMoveNext() == false) {
+                arr = null;
+                return MakeFailure("No closing ] for array");
+            }
+
+            arr = new fsData(result);
+            return fsResult.Success;
+        }
+
+        private fsResult TryParseObject(out fsData obj) {
+            if (Character() != '{') {
+                obj = null;
+                return MakeFailure("Expected initial { when parsing an object");
+            }
+
+            // skip '{'
+            if (TryMoveNext() == false) {
+                obj = null;
+                return MakeFailure("Unexpected end of input when parsing an object");
+            }
+            SkipSpace();
+
+            var result = new Dictionary<string, fsData>(
+                fsGlobalConfig.IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+
+            while (HasValue() && Character() != '}') {
+                fsResult failure;
+
+                // parse the key
+                SkipSpace();
+                string key;
+                failure = TryParseString(out key);
+                if (failure.Failed) {
+                    obj = null;
+                    return failure;
+                }
+                SkipSpace();
+
+                // parse the ':' after the key
+                if (HasValue() == false || Character() != ':' || TryMoveNext() == false) {
+                    obj = null;
+                    return MakeFailure("Expected : after key \"" + key + "\"");
+                }
+                SkipSpace();
+
+                // parse the value
+                fsData value;
+                failure = RunParse(out value);
+                if (failure.Failed) {
+                    obj = null;
+                    return failure;
+                }
+
+                result.Add(key, value);
+
+                // parse the comma
+                SkipSpace();
+                if (HasValue() && Character() == ',') {
+                    if (TryMoveNext() == false) break;
+                    SkipSpace();
+                }
+            }
+
+            // skip the final }
+            if (HasValue() == false || Character() != '}' || TryMoveNext() == false) {
+                obj = null;
+                return MakeFailure("No closing } for object");
+            }
+
+            obj = new fsData(result);
+            return fsResult.Success;
+        }
+
+        private fsResult RunParse(out fsData data) {
+            SkipSpace();
+
+            if (HasValue() == false) {
+                data = default(fsData);
+                return MakeFailure("Unexpected end of input");
+            }
+
+            switch (Character()) {
+                case 'I': // Infinity
+                case 'N': // NaN
+                case '.':
+                case '+':
+                case '-':
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9': return TryParseNumber(out data);
+                case '"': {
+                        string str;
+                        fsResult fail = TryParseString(out str);
+                        if (fail.Failed) {
+                            data = null;
+                            return fail;
+                        }
+                        data = new fsData(str);
+                        return fsResult.Success;
+                    }
+                case '[': return TryParseArray(out data);
+                case '{': return TryParseObject(out data);
+                case 't': return TryParseTrue(out data);
+                case 'f': return TryParseFalse(out data);
+                case 'n': return TryParseNull(out data);
+                default:
+                    data = null;
+                    return MakeFailure("unable to parse; invalid token \"" + Character() + "\"");
+            }
+        }
+
+        /// <summary>
+        /// Parses the specified input. Returns a failure state if parsing
+        /// failed.
+        /// </summary>
+        /// <param name="input">The input to parse.</param>
+        /// <param name="data">
+        /// The parsed data. This is undefined if parsing fails.
+        /// </param>
+        /// <returns>The parsed input.</returns>
+        public static fsResult Parse(string input, out fsData data) {
+            if (string.IsNullOrEmpty(input)) {
+                data = default(fsData);
+                return fsResult.Fail("No input");
+            }
+
+            var context = new fsJsonParser(input);
+            return context.RunParse(out data);
+        }
+
+        /// <summary>
+        /// Helper method for Parse that does not allow the error information to
+        /// be recovered.
+        /// </summary>
+        public static fsData Parse(string input) {
+            fsData data;
+            Parse(input, out data).AssertSuccess();
+            return data;
+        }
+
+        private fsJsonParser(string input) {
+            _input = input;
+            _start = 0;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsJsonParser.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsJsonParser.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 76da27fbb0fa3c4459921ceb0782a604
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsJsonPrinter.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsJsonPrinter.cs
@@ -1,0 +1,285 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace FullSerializer {
+    public static class fsJsonPrinter {
+        /// <summary>
+        /// Inserts the given number of indents into the builder.
+        /// </summary>
+        private static void InsertSpacing(TextWriter stream, int count) {
+            for (int i = 0; i < count; ++i) {
+                stream.Write("    ");
+            }
+        }
+
+        /// <summary>
+        /// Escapes a string.
+        /// </summary>
+        private static string EscapeString(string str) {
+            // Escaping a string is pretty allocation heavy, so we try hard to
+            // not do it.
+
+            bool needsEscape = false;
+            for (int i = 0; i < str.Length; ++i) {
+                char c = str[i];
+
+                // unicode code point
+                int intChar = Convert.ToInt32(c);
+                if (intChar < 0 || intChar > 127) {
+                    needsEscape = true;
+                    break;
+                }
+
+                // standard escape character
+                switch (c) {
+                    case '"':
+                    case '\\':
+                    case '\a':
+                    case '\b':
+                    case '\f':
+                    case '\n':
+                    case '\r':
+                    case '\t':
+                    case '\0':
+                        needsEscape = true;
+                        break;
+                }
+
+                if (needsEscape) {
+                    break;
+                }
+            }
+
+            if (needsEscape == false) {
+                return str;
+            }
+
+            StringBuilder result = new StringBuilder();
+
+            for (int i = 0; i < str.Length; ++i) {
+                char c = str[i];
+
+                // unicode code point
+                int intChar = Convert.ToInt32(c);
+                if (intChar < 0 || intChar > 127) {
+                    result.Append(string.Format("\\u{0:x4} ", intChar).Trim());
+                    continue;
+                }
+
+                // standard escape character
+                switch (c) {
+                    case '"': result.Append("\\\""); continue;
+                    case '\\': result.Append(@"\\"); continue;
+                    case '\a': result.Append(@"\a"); continue;
+                    case '\b': result.Append(@"\b"); continue;
+                    case '\f': result.Append(@"\f"); continue;
+                    case '\n': result.Append(@"\n"); continue;
+                    case '\r': result.Append(@"\r"); continue;
+                    case '\t': result.Append(@"\t"); continue;
+                    case '\0': result.Append(@"\0"); continue;
+                }
+
+                // no escaping needed
+                result.Append(c);
+            }
+            return result.ToString();
+        }
+
+        private static void BuildCompressedString(fsData data, TextWriter stream) {
+            switch (data.Type) {
+                case fsDataType.Null:
+                    stream.Write("null");
+                    break;
+
+                case fsDataType.Boolean:
+                    if (data.AsBool) stream.Write("true");
+                    else stream.Write("false");
+                    break;
+
+                case fsDataType.Double:
+                    // doubles must *always* include a decimal
+                    stream.Write(ConvertDoubleToString(data.AsDouble));
+                    break;
+
+                case fsDataType.Int64:
+                    stream.Write(data.AsInt64);
+                    break;
+
+                case fsDataType.String:
+                    stream.Write('"');
+                    stream.Write(EscapeString(data.AsString));
+                    stream.Write('"');
+                    break;
+
+                case fsDataType.Object: {
+                        stream.Write('{');
+                        bool comma = false;
+                        foreach (var entry in data.AsDictionary) {
+                            if (comma) stream.Write(',');
+                            comma = true;
+                            stream.Write('"');
+                            stream.Write(entry.Key);
+                            stream.Write('"');
+                            stream.Write(":");
+                            BuildCompressedString(entry.Value, stream);
+                        }
+                        stream.Write('}');
+                        break;
+                    }
+
+                case fsDataType.Array: {
+                        stream.Write('[');
+                        bool comma = false;
+                        foreach (var entry in data.AsList) {
+                            if (comma) stream.Write(',');
+                            comma = true;
+                            BuildCompressedString(entry, stream);
+                        }
+                        stream.Write(']');
+                        break;
+                    }
+            }
+        }
+
+        /// <summary>
+        /// Formats this data into the given builder.
+        /// </summary>
+        private static void BuildPrettyString(fsData data, TextWriter stream, int depth) {
+            switch (data.Type) {
+                case fsDataType.Null:
+                    stream.Write("null");
+                    break;
+
+                case fsDataType.Boolean:
+                    if (data.AsBool) stream.Write("true");
+                    else stream.Write("false");
+                    break;
+
+                case fsDataType.Double:
+                    stream.Write(ConvertDoubleToString(data.AsDouble));
+                    break;
+
+                case fsDataType.Int64:
+                    stream.Write(data.AsInt64);
+                    break;
+
+                case fsDataType.String:
+                    stream.Write('"');
+                    stream.Write(EscapeString(data.AsString));
+                    stream.Write('"');
+                    break;
+
+                case fsDataType.Object: {
+                        stream.Write('{');
+                        stream.WriteLine();
+                        bool comma = false;
+                        foreach (var entry in data.AsDictionary) {
+                            if (comma) {
+                                stream.Write(',');
+                                stream.WriteLine();
+                            }
+                            comma = true;
+                            InsertSpacing(stream, depth + 1);
+                            stream.Write('"');
+                            stream.Write(entry.Key);
+                            stream.Write('"');
+                            stream.Write(": ");
+                            BuildPrettyString(entry.Value, stream, depth + 1);
+                        }
+                        stream.WriteLine();
+                        InsertSpacing(stream, depth);
+                        stream.Write('}');
+                        break;
+                    }
+
+                case fsDataType.Array:
+                    // special case for empty lists; we don't put an empty line
+                    // between the brackets
+                    if (data.AsList.Count == 0) {
+                        stream.Write("[]");
+                    }
+                    else {
+                        bool comma = false;
+
+                        stream.Write('[');
+                        stream.WriteLine();
+                        foreach (var entry in data.AsList) {
+                            if (comma) {
+                                stream.Write(',');
+                                stream.WriteLine();
+                            }
+                            comma = true;
+                            InsertSpacing(stream, depth + 1);
+                            BuildPrettyString(entry, stream, depth + 1);
+                        }
+                        stream.WriteLine();
+                        InsertSpacing(stream, depth);
+                        stream.Write(']');
+                    }
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Writes the pretty JSON output data to the given stream.
+        /// </summary>
+        /// <param name="data">The data to print.</param>
+        /// <param name="outputStream">Where to write the printed data.</param>
+        public static void PrettyJson(fsData data, TextWriter outputStream) {
+            BuildPrettyString(data, outputStream, 0);
+        }
+
+        /// <summary>
+        /// Returns the data in a pretty printed JSON format.
+        /// </summary>
+        public static string PrettyJson(fsData data) {
+            var sb = new StringBuilder();
+            using (var writer = new StringWriter(sb)) {
+                BuildPrettyString(data, writer, 0);
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Writes the compressed JSON output data to the given stream.
+        /// </summary>
+        /// <param name="data">The data to print.</param>
+        /// <param name="outputStream">Where to write the printed data.</param>
+        public static void CompressedJson(fsData data, StreamWriter outputStream) {
+            BuildCompressedString(data, outputStream);
+        }
+
+        /// <summary>
+        /// Returns the data in a relatively compressed JSON format.
+        /// </summary>
+        public static string CompressedJson(fsData data) {
+            var sb = new StringBuilder();
+            using (var writer = new StringWriter(sb)) {
+                BuildCompressedString(data, writer);
+                return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Utility method that converts a double to a string.
+        /// </summary>
+        private static string ConvertDoubleToString(double d) {
+            if (Double.IsInfinity(d) || Double.IsNaN(d))
+                return d.ToString(CultureInfo.InvariantCulture);
+
+            string doubledString = d.ToString(CultureInfo.InvariantCulture);
+
+            // NOTE/HACK: If we don't serialize with a period or an exponent,
+            // then the number will be deserialized as an Int64, not a double.
+            if (doubledString.Contains(".") == false &&
+                doubledString.Contains("e") == false &&
+                doubledString.Contains("E") == false) {
+                doubledString += ".0";
+            }
+
+            return doubledString;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsJsonPrinter.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsJsonPrinter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: be309c30e4f28364cadc2d0b014a5333
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsMemberSerialization.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsMemberSerialization.cs
@@ -1,0 +1,23 @@
+﻿namespace FullSerializer {
+    /// <summary>
+    /// Controls how the reflected converter handles member serialization.
+    /// </summary>
+    public enum fsMemberSerialization {
+        /// <summary>
+        /// Only members with [SerializeField] or [fsProperty] attributes are
+        /// serialized.
+        /// </summary>
+        OptIn,
+
+        /// <summary>
+        /// Only members with [NotSerialized] or [fsIgnore] will not be
+        /// serialized.
+        /// </summary>
+        OptOut,
+
+        /// <summary>
+        /// The default member serialization behavior is applied.
+        /// </summary>
+        Default
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsMemberSerialization.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsMemberSerialization.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e2d6fed6217d35c49868389b28b49050
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsObjectAttribute.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsObjectAttribute.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+namespace FullSerializer {
+    /// <summary>
+    /// This attribute controls some serialization behavior for a type. See the
+    /// comments on each of the fields for more information.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public sealed class fsObjectAttribute : Attribute {
+        /// <summary>
+        /// The previous model that should be used if an old version of this
+        /// object is encountered. Using this attribute also requires that the
+        /// type have a public constructor that takes only one parameter, an
+        /// object instance of the given type. Use of this parameter *requires*
+        /// that the VersionString parameter is also set.
+        /// </summary>
+        public Type[] PreviousModels;
+
+        /// <summary>
+        /// The version string to use for this model. This should be unique among
+        /// all prior versions of this model that is supported for importation.
+        /// If PreviousModel is set, then this attribute must also be set. A good
+        /// valid example for this is "v1", "v2", "v3", ...
+        /// </summary>
+        public string VersionString;
+
+        /// <summary>
+        /// This controls the behavior for member serialization. The default
+        /// behavior is fsMemberSerialization.Default.
+        /// </summary>
+        public fsMemberSerialization MemberSerialization = fsMemberSerialization.Default;
+
+        /// <summary>
+        /// Specify a custom converter to use for serialization. The converter
+        /// type needs to derive from fsBaseConverter. This defaults to null.
+        /// </summary>
+        public Type Converter;
+
+        /// <summary>
+        /// Specify a custom processor to use during serialization. The processor
+        /// type needs to derive from fsObjectProcessor and the call to
+        /// CanProcess is not invoked. This defaults to null.
+        /// </summary>
+        public Type Processor;
+
+        public fsObjectAttribute() {
+        }
+        public fsObjectAttribute(string versionString, params Type[] previousModels) {
+            VersionString = versionString;
+            PreviousModels = previousModels;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsObjectAttribute.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsObjectAttribute.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a0824334ca5c07d49b5c390bd38781cf
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsObjectProcessor.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsObjectProcessor.cs
@@ -1,0 +1,92 @@
+﻿using System;
+
+namespace FullSerializer {
+    /// <summary>
+    /// <para>
+    /// Enables injecting code before/after an object has been serialized. This
+    /// is most useful if you want to run the default serialization process but
+    /// apply a pre/post processing step.
+    /// </para>
+    /// <para>
+    /// Multiple object processors can be active at the same time. When running
+    /// they are called in a "nested" fashion - if we have processor1 and
+    /// process2 added to the serializer in that order (p1 then p2), then the
+    /// execution order will be p1#Before p2#Before /serialization/ p2#After
+    /// p1#After.
+    /// </para>
+    /// </summary>
+    public abstract class fsObjectProcessor {
+        /// <summary>
+        /// Is the processor interested in objects of the given type?
+        /// </summary>
+        /// <param name="type">The given type.</param>
+        /// <returns>
+        /// True if the processor should be applied, false otherwise.
+        /// </returns>
+        public virtual bool CanProcess(Type type) { throw new NotImplementedException(); }
+
+        /// <summary>
+        /// Called before serialization.
+        /// </summary>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <param name="instance">The type of the instance.</param>
+        public virtual void OnBeforeSerialize(Type storageType, object instance) { }
+
+        /// <summary>
+        /// Called after serialization.
+        /// </summary>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <param name="instance">The type of the instance.</param>
+        /// <param name="data">The data that was serialized.</param>
+        public virtual void OnAfterSerialize(Type storageType, object instance, ref fsData data) { }
+
+        /// <summary>
+        /// Called before deserialization.
+        /// </summary>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <param name="data">
+        /// The data that will be used for deserialization.
+        /// </param>
+        public virtual void OnBeforeDeserialize(Type storageType, ref fsData data) { }
+
+        /// <summary>
+        /// Called before deserialization has begun but *after* the object
+        /// instance has been created. This will get invoked even if the user
+        /// passed in an existing instance.
+        /// </summary>
+        /// <remarks>
+        /// **IMPORTANT**: The actual instance that gets passed here is *not*
+        ///   guaranteed to be an a subtype of storageType, since the value for
+        /// instance is whatever the active converter returned for
+        /// CreateInstance() - ie, some converters will return dummy types in
+        /// CreateInstance() if instance creation cannot be separated from
+        /// deserialization (ie, KeyValuePair).
+        /// </remarks>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <param name="instance">
+        /// The created object instance. No deserialization has been applied to
+        /// it.
+        /// </param>
+        /// <param name="data">
+        /// The data that will be used for deserialization.
+        /// </param>
+        public virtual void OnBeforeDeserializeAfterInstanceCreation(Type storageType, object instance, ref fsData data) { }
+
+        /// <summary>
+        /// Called after deserialization.
+        /// </summary>
+        /// <param name="storageType">
+        /// The field/property type that is storing the instance.
+        /// </param>
+        /// <param name="instance">The type of the instance.</param>
+        public virtual void OnAfterDeserialize(Type storageType, object instance) { }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsObjectProcessor.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsObjectProcessor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a4f4c2fbbdaec5046adaaa0bb47036a6
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsPropertyAttribute.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsPropertyAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace FullSerializer {
+    /// <summary>
+    /// Explicitly mark a property to be serialized. This can also be used to
+    /// give the name that the property should use during serialization.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class fsPropertyAttribute : Attribute {
+        /// <summary>
+        /// The name of that the property will use in JSON serialization.
+        /// </summary>
+        public string Name;
+
+        /// <summary>
+        /// Use a custom converter for the given type. Specify the converter to
+        /// use using typeof.
+        /// </summary>
+        public Type Converter;
+
+        public fsPropertyAttribute()
+            : this(string.Empty) {
+        }
+
+        public fsPropertyAttribute(string name) {
+            Name = name;
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsPropertyAttribute.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsPropertyAttribute.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b366ee3695fdf924495750c204ea426a
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsResult.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsResult.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FullSerializer {
+    /// <summary>
+    /// The result of some sort of operation. A result is either successful or
+    /// not, but if it is successful then there may be a set of warnings/messages
+    /// associated with it. These warnings describe the performed error recovery
+    /// operations.
+    /// </summary>
+    public struct fsResult {
+        // We cache the empty string array so we can unify some collections
+        // processing code.
+        private static readonly string[] EmptyStringArray = { };
+
+        /// <summary>
+        /// Is this result successful?
+        /// </summary>
+        /// <remarks>
+        /// This is intentionally a `success` state so that when the object is
+        /// default constructed it defaults to a failure state.
+        /// </remarks>
+        private bool _success;
+
+        /// <summary>
+        /// The warning or error messages associated with the result. This may be
+        /// null if there are no messages.
+        /// </summary>
+        private List<string> _messages;
+
+        /// <summary>
+        /// Adds a new message to this result.
+        /// </summary>
+        /// <param name="message"></param>
+        public void AddMessage(string message) {
+            if (_messages == null) {
+                _messages = new List<string>();
+            }
+
+            _messages.Add(message);
+        }
+
+        /// <summary>
+        /// Adds only the messages from the other result into this result,
+        /// ignoring the success/failure status of the other result.
+        /// </summary>
+        public void AddMessages(fsResult result) {
+            if (result._messages == null) {
+                return;
+            }
+
+            if (_messages == null) {
+                _messages = new List<string>();
+            }
+
+            _messages.AddRange(result._messages);
+        }
+
+        /// <summary>
+        /// Merges the other result into this one. If the other result failed,
+        /// then this one too will have failed.
+        /// </summary>
+        /// <remarks>
+        /// Note that you can use += instead of this method so that you don't
+        /// bury the actual method call that is generating the other fsResult.
+        /// </remarks>
+        public fsResult Merge(fsResult other) {
+            // Copy success over
+            _success = _success && other._success;
+
+            // Copy messages over
+            if (other._messages != null) {
+                if (_messages == null) _messages = new List<string>(other._messages);
+                else _messages.AddRange(other._messages);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// A successful result.
+        /// </summary>
+        public static fsResult Success = new fsResult {
+            _success = true
+        };
+
+        /// <summary>
+        /// Create a result that is successful but contains the given warning
+        /// message.
+        /// </summary>
+        public static fsResult Warn(string warning) {
+            return new fsResult {
+                _success = true,
+                _messages = new List<string> { warning }
+            };
+        }
+
+        /// <summary>
+        /// Create a result that failed.
+        /// </summary>
+        public static fsResult Fail(string warning) {
+            return new fsResult {
+                _success = false,
+                _messages = new List<string> { warning }
+            };
+        }
+
+        // TODO: how to make sure this is only used as +=?
+
+        /// <summary>
+        /// Only use this as +=!
+        /// </summary>
+        public static fsResult operator +(fsResult a, fsResult b) {
+            return a.Merge(b);
+        }
+
+        /// <summary>
+        /// Did this result fail? If so, you can see the reasons why in
+        /// `RawMessages`.
+        /// </summary>
+        public bool Failed {
+            get {
+                return _success == false;
+            }
+        }
+
+        /// <summary>
+        /// Was the result a success? Note that even successful operations may
+        /// have warning messages (`RawMessages`) associated with them.
+        /// </summary>
+        public bool Succeeded {
+            get {
+                return _success;
+            }
+        }
+
+        /// <summary>
+        /// Does this result have any warnings? This says nothing about if it
+        /// failed or succeeded, just if it has warning messages associated with
+        /// it.
+        /// </summary>
+        public bool HasWarnings {
+            get {
+                return _messages != null && _messages.Any();
+            }
+        }
+
+        /// <summary>
+        /// A simply utility method that will assert that this result is
+        /// successful. If it is not, then an exception is thrown.
+        /// </summary>
+        public fsResult AssertSuccess() {
+            if (Failed) throw AsException;
+            return this;
+        }
+
+        /// <summary>
+        /// A simple utility method that will assert that this result is
+        /// successful and that there are no warning messages. This throws an
+        /// exception if either of those asserts are false.
+        /// </summary>
+        public fsResult AssertSuccessWithoutWarnings() {
+            if (Failed || RawMessages.Any()) throw AsException;
+            return this;
+        }
+
+        /// <summary>
+        /// Utility method to convert the result to an exception. This method is
+        /// only defined is `Failed` returns true.
+        /// </summary>
+        public Exception AsException {
+            get {
+                if (!Failed && !RawMessages.Any()) throw new Exception("Only a failed result can be converted to an exception");
+                return new Exception(FormattedMessages);
+            }
+        }
+
+        public IEnumerable<string> RawMessages {
+            get {
+                if (_messages != null) {
+                    return _messages;
+                }
+                return EmptyStringArray;
+            }
+        }
+
+        public string FormattedMessages {
+            get {
+                return string.Join(",\n", RawMessages.ToArray());
+            }
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsResult.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsResult.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 54393a5534ff6c74f905d6be1770a1ba
+timeCreated: 1451205257
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/Source/fsSerializer.cs
+++ b/Packages/com.bumimobile.fullserializer/Source/fsSerializer.cs
@@ -1,0 +1,940 @@
+﻿using System;
+using System.Collections.Generic;
+using FullSerializer.Internal;
+
+#if !UNITY_EDITOR && UNITY_WSA
+// For System.Reflection.TypeExtensions
+using System.Reflection;
+#endif
+
+namespace FullSerializer {
+    public class fsSerializer {
+        #region Keys
+        private static HashSet<string> _reservedKeywords;
+        static fsSerializer() {
+            _reservedKeywords = new HashSet<string> {
+                Key_ObjectReference,
+                Key_ObjectDefinition,
+                Key_InstanceType,
+                Key_Version,
+                Key_Content
+            };
+        }
+        /// <summary>
+        /// Returns true if the given key is a special keyword that full
+        /// serializer uses to add additional metadata on top of the emitted
+        /// JSON.
+        /// </summary>
+        public static bool IsReservedKeyword(string key) {
+            return _reservedKeywords.Contains(key);
+        }
+
+        /// <summary>
+        /// This is an object reference in part of a cyclic graph.
+        /// </summary>
+        private static readonly string Key_ObjectReference = string.Format("{0}ref", fsGlobalConfig.InternalFieldPrefix);
+
+        /// <summary>
+        /// This is an object definition, as part of a cyclic graph.
+        /// </summary>
+        private static readonly string Key_ObjectDefinition = string.Format("{0}id", fsGlobalConfig.InternalFieldPrefix);
+
+        /// <summary>
+        /// This specifies the actual type of an object (the instance type was
+        /// different from the field type).
+        /// </summary>
+        private static readonly string Key_InstanceType = string.Format("{0}type", fsGlobalConfig.InternalFieldPrefix);
+
+        /// <summary>
+        /// The version string for the serialized data.
+        /// </summary>
+        private static readonly string Key_Version = string.Format("{0}version", fsGlobalConfig.InternalFieldPrefix);
+
+        /// <summary>
+        /// If we have to add metadata but the original serialized state was not
+        /// a dictionary, then this will contain the original data.
+        /// </summary>
+        private static readonly string Key_Content = string.Format("{0}content", fsGlobalConfig.InternalFieldPrefix);
+
+        private static bool IsObjectReference(fsData data) {
+            if (data.IsDictionary == false) return false;
+            return data.AsDictionary.ContainsKey(Key_ObjectReference);
+        }
+        private static bool IsObjectDefinition(fsData data) {
+            if (data.IsDictionary == false) return false;
+            return data.AsDictionary.ContainsKey(Key_ObjectDefinition);
+        }
+        private static bool IsVersioned(fsData data) {
+            if (data.IsDictionary == false) return false;
+            return data.AsDictionary.ContainsKey(Key_Version);
+        }
+        private static bool IsTypeSpecified(fsData data) {
+            if (data.IsDictionary == false) return false;
+            return data.AsDictionary.ContainsKey(Key_InstanceType);
+        }
+        private static bool IsWrappedData(fsData data) {
+            if (data.IsDictionary == false) return false;
+            return data.AsDictionary.ContainsKey(Key_Content);
+        }
+
+        /// <summary>
+        /// Strips all deserialization metadata from the object, like $type and
+        /// $content fields.
+        /// </summary>
+        /// <remarks>
+        /// After making this call, you will *not* be able to deserialize the
+        /// same object instance. The metadata is strictly necessary for
+        /// deserialization!
+        /// </remarks>
+        public static void StripDeserializationMetadata(ref fsData data) {
+            if (data.IsDictionary && data.AsDictionary.ContainsKey(Key_Content)) {
+                data = data.AsDictionary[Key_Content];
+            }
+
+            if (data.IsDictionary) {
+                var dict = data.AsDictionary;
+                dict.Remove(Key_ObjectReference);
+                dict.Remove(Key_ObjectDefinition);
+                dict.Remove(Key_InstanceType);
+                dict.Remove(Key_Version);
+            }
+        }
+
+        /// <summary>
+        /// This function converts legacy serialization data into the new format,
+        /// so that the import process can be unified and ignore the old format.
+        /// </summary>
+        private static void ConvertLegacyData(ref fsData data) {
+            if (data.IsDictionary == false) return;
+
+            var dict = data.AsDictionary;
+
+            // fast-exit: metadata never had more than two items
+            if (dict.Count > 2) return;
+
+            // Key strings used in the legacy system
+            string referenceIdString = "ReferenceId";
+            string sourceIdString = "SourceId";
+            string sourceDataString = "Data";
+            string typeString = "Type";
+            string typeDataString = "Data";
+
+            // type specifier
+            if (dict.Count == 2 && dict.ContainsKey(typeString) && dict.ContainsKey(typeDataString)) {
+                data = dict[typeDataString];
+                EnsureDictionary(data);
+                ConvertLegacyData(ref data);
+
+                data.AsDictionary[Key_InstanceType] = dict[typeString];
+            }
+
+            // object definition
+            else if (dict.Count == 2 && dict.ContainsKey(sourceIdString) && dict.ContainsKey(sourceDataString)) {
+                data = dict[sourceDataString];
+                EnsureDictionary(data);
+                ConvertLegacyData(ref data);
+
+                data.AsDictionary[Key_ObjectDefinition] = dict[sourceIdString];
+            }
+
+            // object reference
+            else if (dict.Count == 1 && dict.ContainsKey(referenceIdString)) {
+                data = fsData.CreateDictionary();
+                data.AsDictionary[Key_ObjectReference] = dict[referenceIdString];
+            }
+        }
+        #endregion Keys
+
+        #region Utility Methods
+        private static void Invoke_OnBeforeSerialize(List<fsObjectProcessor> processors, Type storageType, object instance) {
+            for (int i = 0; i < processors.Count; ++i) {
+                processors[i].OnBeforeSerialize(storageType, instance);
+            }
+        }
+        private static void Invoke_OnAfterSerialize(List<fsObjectProcessor> processors, Type storageType, object instance, ref fsData data) {
+            // We run the after calls in reverse order; this significantly
+            // reduces the interaction burden between multiple processors - it
+            // makes each one much more independent and ignorant of the other
+            // ones.
+
+            for (int i = processors.Count - 1; i >= 0; --i) {
+                processors[i].OnAfterSerialize(storageType, instance, ref data);
+            }
+        }
+        private static void Invoke_OnBeforeDeserialize(List<fsObjectProcessor> processors, Type storageType, ref fsData data) {
+            for (int i = 0; i < processors.Count; ++i) {
+                processors[i].OnBeforeDeserialize(storageType, ref data);
+            }
+        }
+        private static void Invoke_OnBeforeDeserializeAfterInstanceCreation(List<fsObjectProcessor> processors, Type storageType, object instance, ref fsData data) {
+            for (int i = 0; i < processors.Count; ++i) {
+                processors[i].OnBeforeDeserializeAfterInstanceCreation(storageType, instance, ref data);
+            }
+        }
+        private static void Invoke_OnAfterDeserialize(List<fsObjectProcessor> processors, Type storageType, object instance) {
+            for (int i = processors.Count - 1; i >= 0; --i) {
+                processors[i].OnAfterDeserialize(storageType, instance);
+            }
+        }
+        #endregion Utility Methods
+
+        /// <summary>
+        /// Ensures that the data is a dictionary. If it is not, then it is
+        /// wrapped inside of one.
+        /// </summary>
+        private static void EnsureDictionary(fsData data) {
+            if (data.IsDictionary == false) {
+                var existingData = data.Clone();
+                data.BecomeDictionary();
+                data.AsDictionary[Key_Content] = existingData;
+            }
+        }
+
+        /// <summary>
+        /// This manages instance writing so that we do not write unnecessary $id
+        /// fields. We only need to write out an $id field when there is a
+        /// corresponding $ref field. This is able to write $id references lazily
+        /// because the fsData instance is not actually written out to text until
+        /// we have entirely finished serializing it.
+        /// </summary>
+        internal class fsLazyCycleDefinitionWriter {
+            private Dictionary<int, fsData> _pendingDefinitions = new Dictionary<int, fsData>();
+            private HashSet<int> _references = new HashSet<int>();
+
+            public void WriteDefinition(int id, fsData data) {
+                if (_references.Contains(id)) {
+                    EnsureDictionary(data);
+                    data.AsDictionary[Key_ObjectDefinition] = new fsData(id.ToString());
+                }
+                else {
+                    _pendingDefinitions[id] = data;
+                }
+            }
+
+            public void WriteReference(int id, Dictionary<string, fsData> dict) {
+                // Write the actual definition if necessary
+                if (_pendingDefinitions.ContainsKey(id)) {
+                    var data = _pendingDefinitions[id];
+                    EnsureDictionary(data);
+                    data.AsDictionary[Key_ObjectDefinition] = new fsData(id.ToString());
+                    _pendingDefinitions.Remove(id);
+                }
+                else {
+                    _references.Add(id);
+                }
+
+                // Write the reference
+                dict[Key_ObjectReference] = new fsData(id.ToString());
+            }
+
+            public void Clear() {
+                _pendingDefinitions.Clear();
+                _references.Clear();
+            }
+        }
+
+        /// <summary> Converter type to converter instance lookup table. This
+        /// could likely be stored inside
+        // of _cachedConverters, but there is a semantic difference because
+        // _cachedConverters goes
+        /// from serialized type to converter. </summary>
+        private Dictionary<Type, fsBaseConverter> _cachedConverterTypeInstances;
+
+        /// <summary>
+        /// A cache from type to it's converter.
+        /// </summary>
+        private Dictionary<Type, fsBaseConverter> _cachedConverters;
+
+        /// <summary>
+        /// A cache from type to the set of processors that are interested in it.
+        /// </summary>
+        private Dictionary<Type, List<fsObjectProcessor>> _cachedProcessors;
+
+        /// <summary>
+        /// Converters that can be used for type registration.
+        /// </summary>
+        private readonly List<fsConverter> _availableConverters;
+
+        /// <summary>
+        /// Direct converters (optimized _converters). We use these so we don't
+        /// have to perform a scan through every item in _converters and can
+        /// instead just do an O(1) lookup. This is potentially important to perf
+        /// when there are a ton of direct converters.
+        /// </summary>
+        private readonly Dictionary<Type, fsDirectConverter> _availableDirectConverters;
+
+        /// <summary>
+        /// Processors that are available.
+        /// </summary>
+        private readonly List<fsObjectProcessor> _processors;
+
+        /// <summary>
+        /// Reference manager for cycle detection.
+        /// </summary>
+        private readonly fsCyclicReferenceManager _references;
+        private readonly fsLazyCycleDefinitionWriter _lazyReferenceWriter;
+
+        /// <summary>
+        /// Allow the user to provide default storage types for interfaces and abstract
+        /// classes. For example, a model could have IList{int} as a parameter, but the
+        /// serialization data does not specify a List{int} type. A IList{} -> List{}
+        /// remapping will cause List{} to be used as the default storage type. see
+        /// https://github.com/jacobdufault/fullserializer/issues/120 for additional
+        /// context.
+        /// </summary>
+        private readonly Dictionary<Type, Type> _abstractTypeRemap;
+
+        private void RemapAbstractStorageTypeToDefaultType(ref Type storageType) {
+            if ((storageType.IsInterface() || storageType.IsAbstract()) == false)
+                return;
+
+            if (storageType.IsGenericType()) {
+                Type remappedGenericType;
+                if (_abstractTypeRemap.TryGetValue(storageType.GetGenericTypeDefinition(), out remappedGenericType)) {
+                    Type[] genericArguments = storageType.GetGenericArguments();
+                    storageType = remappedGenericType.MakeGenericType(genericArguments);
+                }
+            }
+
+            else {
+                Type remappedType;
+                if (_abstractTypeRemap.TryGetValue(storageType, out remappedType))
+                    storageType = remappedType;
+            }
+        }
+
+        public fsSerializer() {
+            _cachedConverterTypeInstances = new Dictionary<Type, fsBaseConverter>();
+            _cachedConverters = new Dictionary<Type, fsBaseConverter>();
+            _cachedProcessors = new Dictionary<Type, List<fsObjectProcessor>>();
+
+            _references = new fsCyclicReferenceManager();
+            _lazyReferenceWriter = new fsLazyCycleDefinitionWriter();
+
+            // note: The order here is important. Items at the beginning of this
+            //       list will be used before converters at the end. Converters
+            //       added via AddConverter() are added to the front of the list.
+            _availableConverters = new List<fsConverter> {
+                new fsNullableConverter { Serializer = this },
+                new fsGuidConverter { Serializer = this },
+                new fsTypeConverter { Serializer = this },
+                new fsDateConverter { Serializer = this },
+                new fsEnumConverter { Serializer = this },
+                new fsPrimitiveConverter { Serializer = this },
+                new fsArrayConverter { Serializer = this },
+                new fsDictionaryConverter { Serializer = this },
+                new fsIEnumerableConverter { Serializer = this },
+                new fsKeyValuePairConverter { Serializer = this },
+                new fsWeakReferenceConverter { Serializer = this },
+                new fsReflectedConverter { Serializer = this }
+            };
+            _availableDirectConverters = new Dictionary<Type, fsDirectConverter>();
+
+            _processors = new List<fsObjectProcessor>() {
+                new fsSerializationCallbackProcessor()
+            };
+
+#if !NO_UNITY
+            _processors.Add(new fsSerializationCallbackReceiverProcessor());
+#endif
+
+            _abstractTypeRemap = new Dictionary<Type, Type>();
+            SetDefaultStorageType(typeof(ICollection<>), typeof(List<>));
+            SetDefaultStorageType(typeof(IList<>), typeof(List<>));
+            SetDefaultStorageType(typeof(IDictionary<,>), typeof(Dictionary<,>));
+
+            Context = new fsContext();
+            Config = new fsConfig();
+
+            // Register the converters from the registrar
+            foreach (var converterType in fsConverterRegistrar.Converters) {
+                AddConverter((fsBaseConverter)Activator.CreateInstance(converterType));
+            }
+        }
+
+        /// <summary>
+        /// A context object that fsConverters can use to customize how they
+        /// operate.
+        /// </summary>
+        public fsContext Context;
+
+        /// <summary>
+        /// Configuration options. Also see fsGlobalConfig.
+        /// </summary>
+        public fsConfig Config;
+
+        /// <summary>
+        /// Add a new processor to the serializer. Multiple processors can run at
+        /// the same time in the same order they were added in.
+        /// </summary>
+        /// <param name="processor">The processor to add.</param>
+        public void AddProcessor(fsObjectProcessor processor) {
+            _processors.Add(processor);
+
+            // We need to reset our cached processor set, as it could be invalid
+            // with the new processor. Ideally, _cachedProcessors should be empty
+            // (as the user should fully setup the serializer before actually
+            // using it), but there is no guarantee.
+            _cachedProcessors = new Dictionary<Type, List<fsObjectProcessor>>();
+        }
+
+        /// <summary>
+        /// Remove all processors which derive from TProcessor.
+        /// </summary>
+        public void RemoveProcessor<TProcessor>() {
+            int i = 0;
+            while (i < _processors.Count) {
+                if (_processors[i] is TProcessor) {
+                    _processors.RemoveAt(i);
+                }
+                else {
+                    ++i;
+                }
+            }
+
+            // We need to reset our cached processor set, as it could be invalid
+            // with the new processor. Ideally, _cachedProcessors should be empty
+            // (as the user should fully setup the serializer before actually
+            // using it), but there is no guarantee.
+            _cachedProcessors = new Dictionary<Type, List<fsObjectProcessor>>();
+        }
+
+        /// <summary>
+        /// Provide a default storage type for the given abstract or interface type. If
+        /// a type is deserialized which contains an interface/abstract field type and a
+        /// mapping is provided, the mapped type will be used by default. For example,
+        /// IList{T} => List{T} or IDictionary{TKey, TValue} => Dictionary{TKey, TValue}.
+        /// </summary>
+        public void SetDefaultStorageType(Type abstractType, Type defaultStorageType) {
+            if ((abstractType.IsInterface() || abstractType.IsAbstract()) == false)
+                throw new ArgumentException("|abstractType| must be an interface or abstract type");
+            _abstractTypeRemap[abstractType] = defaultStorageType;
+        }
+
+        /// <summary>
+        /// Fetches all of the processors for the given type.
+        /// </summary>
+        private List<fsObjectProcessor> GetProcessors(Type type) {
+            List<fsObjectProcessor> processors;
+
+            // Check to see if the user has defined a custom processor for the
+            // type. If they have, then we don't need to scan through all of the
+            // processor to check which one can process the type; instead, we
+            // directly use the specified processor.
+            var attr = fsPortableReflection.GetAttribute<fsObjectAttribute>(type);
+            if (attr != null && attr.Processor != null) {
+                var processor = (fsObjectProcessor)Activator.CreateInstance(attr.Processor);
+                processors = new List<fsObjectProcessor>();
+                processors.Add(processor);
+                _cachedProcessors[type] = processors;
+            }
+            else if (_cachedProcessors.TryGetValue(type, out processors) == false) {
+                processors = new List<fsObjectProcessor>();
+
+                for (int i = 0; i < _processors.Count; ++i) {
+                    var processor = _processors[i];
+                    if (processor.CanProcess(type)) {
+                        processors.Add(processor);
+                    }
+                }
+
+                _cachedProcessors[type] = processors;
+            }
+
+            return processors;
+        }
+
+        /// <summary>
+        /// Adds a new converter that can be used to customize how an object is
+        /// serialized and deserialized.
+        /// </summary>
+        public void AddConverter(fsBaseConverter converter) {
+            if (converter.Serializer != null) {
+                throw new InvalidOperationException("Cannot add a single converter instance to " +
+                    "multiple fsConverters -- please construct a new instance for " + converter);
+            }
+
+            // TODO: wrap inside of a ConverterManager so we can control
+            //       _converters and _cachedConverters lifetime
+            if (converter is fsDirectConverter) {
+                var directConverter = (fsDirectConverter)converter;
+                _availableDirectConverters[directConverter.ModelType] = directConverter;
+            }
+            else if (converter is fsConverter) {
+                _availableConverters.Insert(0, (fsConverter)converter);
+            }
+            else {
+                throw new InvalidOperationException("Unable to add converter " + converter +
+                    "; the type association strategy is unknown. Please use either " +
+                    "fsDirectConverter or fsConverter as your base type.");
+            }
+
+            converter.Serializer = this;
+
+            // We need to reset our cached converter set, as it could be invalid
+            // with the new converter. Ideally, _cachedConverters should be empty
+            // (as the user should fully setup the serializer before actually
+            // using it), but there is no guarantee.
+            _cachedConverters = new Dictionary<Type, fsBaseConverter>();
+        }
+
+        /// <summary>
+        /// Fetches a converter that can serialize/deserialize the given type.
+        /// </summary>
+        private fsBaseConverter GetConverter(Type type, Type overrideConverterType) {
+            // Use an override converter type instead if that's what the user has
+            // requested.
+            if (overrideConverterType != null) {
+                fsBaseConverter overrideConverter;
+                if (_cachedConverterTypeInstances.TryGetValue(overrideConverterType, out overrideConverter) == false) {
+                    overrideConverter = (fsBaseConverter)Activator.CreateInstance(overrideConverterType);
+                    overrideConverter.Serializer = this;
+                    _cachedConverterTypeInstances[overrideConverterType] = overrideConverter;
+                }
+
+                return overrideConverter;
+            }
+
+            // Try to lookup an existing converter.
+            fsBaseConverter converter;
+            if (_cachedConverters.TryGetValue(type, out converter)) {
+                return converter;
+            }
+
+            // Check to see if the user has defined a custom converter for the
+            // type. If they have, then we don't need to scan through all of the
+            // converters to check which one can process the type; instead, we
+            // directly use the specified converter.
+            {
+                var attr = fsPortableReflection.GetAttribute<fsObjectAttribute>(type);
+                if (attr != null && attr.Converter != null) {
+                    converter = (fsBaseConverter)Activator.CreateInstance(attr.Converter);
+                    converter.Serializer = this;
+                    return _cachedConverters[type] = converter;
+                }
+            }
+
+            // Check for a [fsForward] attribute.
+            {
+                var attr = fsPortableReflection.GetAttribute<fsForwardAttribute>(type);
+                if (attr != null) {
+                    converter = new fsForwardConverter(attr);
+                    converter.Serializer = this;
+                    return _cachedConverters[type] = converter;
+                }
+            }
+
+            // There is no specific converter specified; try all of the general
+            // ones to see which ones matches.
+            if (_cachedConverters.TryGetValue(type, out converter) == false) {
+                if (_availableDirectConverters.ContainsKey(type)) {
+                    converter = _availableDirectConverters[type];
+                    return _cachedConverters[type] = converter;
+                }
+                else {
+                    for (int i = 0; i < _availableConverters.Count; ++i) {
+                        if (_availableConverters[i].CanProcess(type)) {
+                            converter = _availableConverters[i];
+                            return _cachedConverters[type] = converter;
+                        }
+                    }
+                }
+            }
+
+            throw new InvalidOperationException("Internal error -- could not find a converter for " + type);
+        }
+
+        /// <summary>
+        /// Helper method that simply forwards the call to
+        /// TrySerialize(typeof(T), instance, out data);
+        /// </summary>
+        public fsResult TrySerialize<T>(T instance, out fsData data) {
+            return TrySerialize(typeof(T), instance, out data);
+        }
+
+        /// <summary>
+        /// Generic wrapper around TryDeserialize that simply forwards the call.
+        /// </summary>
+        public fsResult TryDeserialize<T>(fsData data, ref T instance) {
+            object boxed = instance;
+            var fail = TryDeserialize(data, typeof(T), ref boxed);
+            if (fail.Succeeded) {
+                instance = (T)boxed;
+            }
+            return fail;
+        }
+
+        /// <summary>
+        /// Serialize the given value.
+        /// </summary>
+        /// <param name="storageType">
+        /// The type of field/property that stores the object instance. This is
+        /// important particularly for inheritance, as a field storing an
+        /// IInterface instance should have type information included.
+        /// </param>
+        /// <param name="instance">
+        /// The actual object instance to serialize.
+        /// </param>
+        /// <param name="data">The serialized state of the object.</param>
+        /// <returns>If serialization was successful.</returns>
+        public fsResult TrySerialize(Type storageType, object instance, out fsData data) {
+            return TrySerialize(storageType, null, instance, out data);
+        }
+
+        /// <summary>
+        /// Serialize the given value.
+        /// </summary>
+        /// <param name="storageType">
+        /// The type of field/property that stores the object instance. This is
+        /// important particularly for inheritance, as a field storing an
+        /// IInterface instance should have type information included.
+        /// </param>
+        /// <param name="overrideConverterType">
+        /// An fsBaseConverter derived type that will be used to serialize the
+        /// object instead of the converter found via the normal discovery
+        /// mechanisms.
+        /// </param>
+        /// <param name="instance">
+        /// The actual object instance to serialize.
+        /// </param>
+        /// <param name="data">The serialized state of the object.</param>
+        /// <returns>If serialization was successful.</returns>
+        public fsResult TrySerialize(Type storageType, Type overrideConverterType, object instance, out fsData data) {
+            var processors = GetProcessors(instance == null ? storageType : instance.GetType());
+
+            Invoke_OnBeforeSerialize(processors, storageType, instance);
+
+            // We always serialize null directly as null
+            if (ReferenceEquals(instance, null)) {
+                data = new fsData();
+                Invoke_OnAfterSerialize(processors, storageType, instance, ref data);
+                return fsResult.Success;
+            }
+
+            var result = InternalSerialize_1_ProcessCycles(storageType, overrideConverterType, instance, out data);
+            Invoke_OnAfterSerialize(processors, storageType, instance, ref data);
+            return result;
+        }
+
+        private fsResult InternalSerialize_1_ProcessCycles(Type storageType, Type overrideConverterType, object instance, out fsData data) {
+            // We have an object definition to serialize.
+            try {
+                // Note that we enter the reference group at the beginning of
+                // serialization so that we support references that are at equal
+                // serialization levels, not just nested serialization levels,
+                // within the given subobject. A prime example is serialization a
+                // list of references.
+                _references.Enter();
+
+                // This type does not need cycle support.
+                var converter = GetConverter(instance.GetType(), overrideConverterType);
+                if (converter.RequestCycleSupport(instance.GetType()) == false) {
+                    return InternalSerialize_2_Inheritance(storageType, overrideConverterType, instance, out data);
+                }
+
+                // We've already serialized this object instance (or it is
+                // pending higher up on the call stack). Just serialize a
+                // reference to it to escape the cycle.
+                //
+                // note: We serialize the int as a string to so that we don't
+                //       lose any information in a conversion to/from double.
+                if (_references.IsReference(instance)) {
+                    data = fsData.CreateDictionary();
+                    _lazyReferenceWriter.WriteReference(_references.GetReferenceId(instance), data.AsDictionary);
+                    return fsResult.Success;
+                }
+
+                // Mark inside the object graph that we've serialized the
+                // instance. We do this *before* serialization so that if we get
+                // back into this function recursively, it'll already be marked
+                // and we can handle the cycle properly without going into an
+                // infinite loop.
+                _references.MarkSerialized(instance);
+
+                // We've created the cycle metadata, so we can now serialize the
+                // actual object. InternalSerialize will handle inheritance
+                // correctly for us.
+                var result = InternalSerialize_2_Inheritance(storageType, overrideConverterType, instance, out data);
+                if (result.Failed) return result;
+
+                _lazyReferenceWriter.WriteDefinition(_references.GetReferenceId(instance), data);
+
+                return result;
+            }
+            finally {
+                if (_references.Exit()) {
+                    _lazyReferenceWriter.Clear();
+                }
+            }
+        }
+        private fsResult InternalSerialize_2_Inheritance(Type storageType, Type overrideConverterType, object instance, out fsData data) {
+            // Serialize the actual object with the field type being the same as
+            // the object type so that we won't go into an infinite loop.
+            var serializeResult = InternalSerialize_3_ProcessVersioning(overrideConverterType, instance, out data);
+            if (serializeResult.Failed) return serializeResult;
+
+            // Do we need to add type information? If the field type and the
+            // instance type are different then we will not be able to recover
+            // the correct instance type from the field type when we deserialize
+            // the object.
+            //
+            // Note: We allow converters to request that we do *not* add type
+            //       information.
+            if (storageType != instance.GetType() &&
+                GetConverter(storageType, overrideConverterType).RequestInheritanceSupport(storageType)) {
+                // Add the inheritance metadata
+                EnsureDictionary(data);
+                data.AsDictionary[Key_InstanceType] = new fsData(instance.GetType().FullName);
+            }
+
+            return serializeResult;
+        }
+
+        private fsResult InternalSerialize_3_ProcessVersioning(Type overrideConverterType, object instance, out fsData data) {
+            // note: We do not have to take a Type parameter here, since at this
+            //       point in the serialization algorithm inheritance has
+            // *always* been handled. If we took a type parameter, it will
+            // *always* be equal to instance.GetType(), so why bother taking the
+            //  parameter?
+
+            // Check to see if there is versioning information for this type. If
+            // so, then we need to serialize it.
+            fsOption<fsVersionedType> optionalVersionedType = fsVersionManager.GetVersionedType(instance.GetType());
+            if (optionalVersionedType.HasValue) {
+                fsVersionedType versionedType = optionalVersionedType.Value;
+
+                // Serialize the actual object content; we'll just wrap it with
+                // versioning metadata here.
+                var result = InternalSerialize_4_Converter(overrideConverterType, instance, out data);
+                if (result.Failed) return result;
+
+                // Add the versioning information
+                EnsureDictionary(data);
+                data.AsDictionary[Key_Version] = new fsData(versionedType.VersionString);
+
+                return result;
+            }
+
+            // This type has no versioning information -- directly serialize it
+            // using the selected converter.
+            return InternalSerialize_4_Converter(overrideConverterType, instance, out data);
+        }
+        private fsResult InternalSerialize_4_Converter(Type overrideConverterType, object instance, out fsData data) {
+            var instanceType = instance.GetType();
+            return GetConverter(instanceType, overrideConverterType).TrySerialize(instance, out data, instanceType);
+        }
+
+        /// <summary>
+        /// Attempts to deserialize a value from a serialized state.
+        /// </summary>
+        public fsResult TryDeserialize(fsData data, Type storageType, ref object result) {
+            return TryDeserialize(data, storageType, null, ref result);
+        }
+
+        /// <summary>
+        /// Attempts to deserialize a value from a serialized state.
+        /// </summary>
+        public fsResult TryDeserialize(fsData data, Type storageType, Type overrideConverterType, ref object result) {
+            if (data.IsNull) {
+                result = null;
+                var processors = GetProcessors(storageType);
+                Invoke_OnBeforeDeserialize(processors, storageType, ref data);
+                Invoke_OnAfterDeserialize(processors, storageType, null);
+                return fsResult.Success;
+            }
+
+            // Convert legacy data into modern style data
+            ConvertLegacyData(ref data);
+
+            try {
+                // We wrap the entire deserialize call in a reference group so
+                // that we can properly deserialize a "parallel" set of
+                // references, ie, a list of objects that are cyclic w.r.t. the
+                // list
+                _references.Enter();
+
+                List<fsObjectProcessor> processors;
+                var r = InternalDeserialize_1_CycleReference(overrideConverterType, data, storageType, ref result, out processors);
+                if (r.Succeeded) {
+                    Invoke_OnAfterDeserialize(processors, storageType, result);
+                }
+                return r;
+            }
+            finally {
+                _references.Exit();
+            }
+        }
+
+        private fsResult InternalDeserialize_1_CycleReference(Type overrideConverterType, fsData data, Type storageType, ref object result, out List<fsObjectProcessor> processors) {
+            // We handle object references first because we could be
+            // deserializing a cyclic type that is inherited. If that is the
+            // case, then if we handle references after inheritances we will try
+            // to create an object instance for an abstract/interface type.
+
+            // While object construction should technically be two-pass, we can
+            // do it in one pass because of how serialization happens. We
+            // traverse the serialization graph in the same order during
+            // serialization and deserialization, so the first time we encounter
+            // an object it'll always be the definition. Any times after that it
+            // will be a reference. Because of this, if we encounter a reference
+            // then we will have *always* already encountered the definition for
+            // it.
+            if (IsObjectReference(data)) {
+                int refId = int.Parse(data.AsDictionary[Key_ObjectReference].AsString);
+                result = _references.GetReferenceObject(refId);
+                processors = GetProcessors(result.GetType());
+                return fsResult.Success;
+            }
+
+            return InternalDeserialize_2_Version(overrideConverterType, data, storageType, ref result, out processors);
+        }
+
+        private fsResult InternalDeserialize_2_Version(Type overrideConverterType, fsData data, Type storageType, ref object result, out List<fsObjectProcessor> processors) {
+            if (IsVersioned(data)) {
+                // data is versioned, but we might not need to do a migration
+                string version = data.AsDictionary[Key_Version].AsString;
+
+                fsOption<fsVersionedType> versionedType = fsVersionManager.GetVersionedType(storageType);
+                if (versionedType.HasValue &&
+                    versionedType.Value.VersionString != version) {
+                    // we have to do a migration
+                    var deserializeResult = fsResult.Success;
+
+                    List<fsVersionedType> path;
+                    deserializeResult += fsVersionManager.GetVersionImportPath(version, versionedType.Value, out path);
+                    if (deserializeResult.Failed) {
+                        processors = GetProcessors(storageType);
+                        return deserializeResult;
+                    }
+
+                    // deserialize as the original type
+                    deserializeResult += InternalDeserialize_3_Inheritance(overrideConverterType, data, path[0].ModelType, ref result, out processors);
+                    if (deserializeResult.Failed) return deserializeResult;
+
+                    // TODO: we probably should be invoking object processors all
+                    //       along this pipeline
+                    for (int i = 1; i < path.Count; ++i) {
+                        result = path[i].Migrate(result);
+                    }
+
+                    // Our data contained an object definition ($id) that was
+                    // added to _references in step 4. However, in case we are
+                    // doing versioning, it will contain the old version. To make
+                    // sure future references to this object end up referencing
+                    // the migrated version, we must update the reference.
+                    if (IsObjectDefinition(data)) {
+                        int sourceId = int.Parse(data.AsDictionary[Key_ObjectDefinition].AsString);
+                        _references.AddReferenceWithId(sourceId, result);
+                    }
+
+                    processors = GetProcessors(deserializeResult.GetType());
+                    return deserializeResult;
+                }
+            }
+
+            return InternalDeserialize_3_Inheritance(overrideConverterType, data, storageType, ref result, out processors);
+        }
+
+        private fsResult InternalDeserialize_3_Inheritance(Type overrideConverterType, fsData data, Type storageType, ref object result, out List<fsObjectProcessor> processors) {
+            var deserializeResult = fsResult.Success;
+
+            Type objectType = storageType;
+
+            // If the serialized state contains type information, then we need to
+            // make sure to update our objectType and data to the proper values
+            // so that when we construct an object instance later and run
+            // deserialization we run it on the proper type.
+            if (IsTypeSpecified(data)) {
+                fsData typeNameData = data.AsDictionary[Key_InstanceType];
+
+                // we wrap everything in a do while false loop so we can break
+                // out it
+                do {
+                    if (typeNameData.IsString == false) {
+                        deserializeResult.AddMessage(Key_InstanceType + " value must be a string (in " + data + ")");
+                        break;
+                    }
+
+                    string typeName = typeNameData.AsString;
+                    Type type = fsTypeCache.GetType(typeName);
+                    if (type == null) {
+                        deserializeResult += fsResult.Fail("Unable to locate specified type \"" + typeName + "\"");
+                        break;
+                    }
+
+                    if (storageType.IsAssignableFrom(type) == false) {
+                        deserializeResult.AddMessage("Ignoring type specifier; a field/property of type " + storageType + " cannot hold an instance of " + type);
+                        break;
+                    }
+
+                    objectType = type;
+                } while (false);
+            }
+            RemapAbstractStorageTypeToDefaultType(ref objectType);
+
+            // We wait until here to actually Invoke_OnBeforeDeserialize because
+            // we do not have the correct set of processors to invoke until
+            // *after* we have resolved the proper type to use for
+            // deserialization.
+            processors = GetProcessors(objectType);
+
+            if (deserializeResult.Failed)
+                return deserializeResult;
+
+            Invoke_OnBeforeDeserialize(processors, storageType, ref data);
+
+            // Construct an object instance if we don't have one already. We also
+            // need to construct an instance if the result type is of the wrong
+            // type, which may be the case when we have a versioned import graph.
+            if (ReferenceEquals(result, null) || result.GetType() != objectType) {
+                result = GetConverter(objectType, overrideConverterType).CreateInstance(data, objectType);
+            }
+
+            // We call OnBeforeDeserializeAfterInstanceCreation here because we
+            // still want to invoke the method even if the user passed in an
+            // existing instance.
+            Invoke_OnBeforeDeserializeAfterInstanceCreation(processors, storageType, result, ref data);
+
+            // NOTE: It is critically important that we pass the actual
+            //       objectType down instead of using result.GetType() because it
+            //       is not guaranteed that result.GetType() will equal
+            //       objectType, especially because some converters are known to
+            //       return dummy values for CreateInstance() (for example, the
+            //       default behavior for structs is to just return the type of
+            //       the struct).
+
+            return deserializeResult += InternalDeserialize_4_Cycles(overrideConverterType, data, objectType, ref result);
+        }
+
+        private fsResult InternalDeserialize_4_Cycles(Type overrideConverterType, fsData data, Type resultType, ref object result) {
+            if (IsObjectDefinition(data)) {
+                // NOTE: object references are handled at stage 1
+
+                // If this is a definition, then we have a serialization
+                // invariant that this is the first time we have encountered the
+                // object (TODO: verify in the deserialization logic)
+
+                // Since at this stage in the deserialization process we already
+                // have access to the object instance, so we just need to sync
+                // the object id to the references database so that when we
+                // encounter the instance we lookup this same object. We want to
+                // do this before actually deserializing the object because when
+                // deserializing the object there may be references to itself.
+
+                int sourceId = int.Parse(data.AsDictionary[Key_ObjectDefinition].AsString);
+                _references.AddReferenceWithId(sourceId, result);
+            }
+
+            // Nothing special, go through the standard deserialization logic.
+            return InternalDeserialize_5_Converter(overrideConverterType, data, resultType, ref result);
+        }
+
+        private fsResult InternalDeserialize_5_Converter(Type overrideConverterType, fsData data, Type resultType, ref object result) {
+            if (IsWrappedData(data)) {
+                data = data.AsDictionary[Key_Content];
+            }
+
+            return GetConverter(resultType, overrideConverterType).TryDeserialize(data, ref result, resultType);
+        }
+    }
+}

--- a/Packages/com.bumimobile.fullserializer/Source/fsSerializer.cs.meta
+++ b/Packages/com.bumimobile.fullserializer/Source/fsSerializer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b904dc26e957fde4fb90a0d405d710ee
+timeCreated: 1451205258
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.bumimobile.fullserializer/package.json
+++ b/Packages/com.bumimobile.fullserializer/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "com.bumimobile.fullserializer",
+  "displayName": "Bumi Mobile FullSerializer",
+  "version": "0.1.0",
+  "unity": "2021.3",
+  "description": "FullSerializer integration for Bumi Mobile modules.",
+  "keywords": [
+    "bumi",
+    "fullserializer",
+    "module"
+  ],
+  "category": "Framework",
+  "dependencies": {
+    "com.bumimobile.core": "0.1.1"
+  }
+}

--- a/Packages/com.bumimobile.fullserializer/package.json.meta
+++ b/Packages/com.bumimobile.fullserializer/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
-TextScriptImporter:
+guid: 6514fddbb0af4df4884c8a846505a430
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Packages/com.bumimobile.save/CHANGELOG.md
+++ b/Packages/com.bumimobile.save/CHANGELOG.md
@@ -8,6 +8,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 - (Add unreleased changes here)
 
+## [0.1.2] - 2025-12-02
+
+### Added
+
+- Integrated `com.bumimobile.security` and `com.bumimobile.fullserializer` directly into the Save package so cloud backends no longer rely on Unity Visual Scripting assemblies.
+- Encrypted Google Play Games and Firebase cloud payloads using `SaveCrypto`, ensuring user data stays encrypted at rest.
+
+### Changed
+
+- Updated `BumiMobile.Save.asmdef` references and scripting defines so Firebase (`BUMI_SAVE_CLOUD_FIREBASE`) and Google Play Games (`BUMI_SAVE_CLOUD_GPGS`) code only compiles when the respective packages are installed.
+- Switched serializer pipelines to the new `FullSerializer` namespace and UTF-8 encoding for cloud traffic.
+
 ## [0.1.0] - 2025-11-14
 
 ### Added

--- a/Packages/com.bumimobile.save/Runtime/BumiMobile.Save.asmdef
+++ b/Packages/com.bumimobile.save/Runtime/BumiMobile.Save.asmdef
@@ -1,7 +1,9 @@
 {
   "name": "BumiMobile.Save",
   "references": [
-    "BumiMobile.Core"
+    "BumiMobile.Core",
+    "BumiMobile.Security",
+    "BumiMobile.FullSerializer"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],
@@ -10,5 +12,17 @@
   "precompiledReferences": [],
   "autoReferenced": true,
   "defineConstraints": [],
+  "versionDefines": [
+    {
+      "name": "com.google.play.games",
+      "expression": "0.0.0",
+      "define": "BUMI_SAVE_CLOUD_GPGS"
+    },
+    {
+      "name": "com.google.firebase.firestore",
+      "expression": "0.0.0",
+      "define": "BUMI_SAVE_CLOUD_FIREBASE"
+    }
+  ],
   "noEngineReferences": false
 }

--- a/Packages/com.bumimobile.save/Runtime/Wrappers/AndroidSaveWrapper.cs
+++ b/Packages/com.bumimobile.save/Runtime/Wrappers/AndroidSaveWrapper.cs
@@ -1,0 +1,252 @@
+#if UNITY_ANDROID && BUMI_SAVE_CLOUD_GPGS
+using System;
+using System.Text;
+using FullSerializer;
+using GooglePlayGames;
+using GooglePlayGames.BasicApi;
+using GooglePlayGames.BasicApi.SavedGame;
+using UnityEngine;
+using UnityEngine.SocialPlatforms;
+using Watermelon.Security;
+
+namespace BumiMobile
+{
+    /// <summary>
+    /// Android wrapper: lokal (fallback) + Cloud (GPGS Saved Games).
+    /// - Login dilakukan di sini (silent -> prompt sekali).
+    /// - Slot cloud: "save"
+    /// </summary>
+    public sealed class AndroidSaveWrapper : BaseSaveWrapper
+    {
+        private readonly DefaultSaveWrapper local = new DefaultSaveWrapper();
+
+        private const string SLOT_NAME = "save";
+
+        public override bool SupportsCloud => true;
+
+        // ===== Lokal I/O selalu tersedia (fallback) =====
+        public override GlobalSave Load(string fileName) => local.Load(fileName);
+
+        public override void Save(GlobalSave globalSave, string fileName)
+        {
+            local.Save(globalSave, fileName);
+            SaveCloud(globalSave);
+        }
+        public override void Delete(string fileName) => local.Delete(fileName);
+        public override bool UseThreads() => false;
+
+        // ====== CLOUD (Login + Read/Write) ======
+        public override void BeginCloudLoad(Action<GlobalSave> onLoaded)
+        {
+#if UNITY_ANDROID
+            EnsureActivated();
+
+            EnsureAuthenticated(canPromptOnce: true, authed =>
+            {
+                if (!authed)
+                {
+                    // Gagal login → fallback ke lokal
+                    onLoaded?.Invoke(null);
+                    return;
+                }
+
+                var client = PlayGamesPlatform.Instance.SavedGame;
+
+                client.OpenWithAutomaticConflictResolution(
+                    SLOT_NAME,
+                    DataSource.ReadCacheOrNetwork,
+                    ConflictResolutionStrategy.UseLongestPlaytime,
+                    (openStatus, meta) =>
+                    {
+                        if (openStatus != SavedGameRequestStatus.Success)
+                        {
+                            Debug.LogError("[Save Controller] Cloud Open failed: " + openStatus);
+                            onLoaded?.Invoke(null);
+                            return;
+                        }
+
+                        client.ReadBinaryData(meta, (readStatus, data) =>
+                        {
+                            if (readStatus != SavedGameRequestStatus.Success || data == null || data.Length == 0)
+                            {
+                                // Kosong atau gagal → anggap fresh
+                                onLoaded?.Invoke(new GlobalSave());
+                                return;
+                            }
+
+                            try
+                            {
+                                string json = Encoding.UTF8.GetString(data);
+                                if (string.IsNullOrEmpty(json))
+                                {
+                                    onLoaded?.Invoke(new GlobalSave());
+                                    return;
+                                }
+
+                                var uid = GetCloudUserId(PlayGamesPlatform.Instance?.localUser);
+                                json = SaveCrypto.DecryptJsonIfNeeded(json, uid);
+
+                                object box = null;
+                                var parsed = fsJsonParser.Parse(json);
+                                var fs = new fsSerializer();
+                                fs.TryDeserialize(parsed, typeof(GlobalSave), ref box)
+                                  .AssertSuccessWithoutWarnings();
+
+                                var gs = box as GlobalSave ?? new GlobalSave();
+                                Debug.Log("[Save Controller] Cloud Open " + openStatus);
+                                onLoaded?.Invoke(gs);
+                            }
+                            catch (Exception e)
+                            {
+                                UnityEngine.Debug.LogError("[Save Controller] Cloud Deserialize failed: " + e.Message);
+                                onLoaded?.Invoke(new GlobalSave());
+                            }
+                        });
+                    });
+            });
+#else
+            onLoaded?.Invoke(null);
+#endif
+        }
+
+        public override void SaveCloud(GlobalSave globalSave)
+        {
+#if UNITY_ANDROID
+            if (globalSave == null) return;
+
+            EnsureActivated();
+            EnsureAuthenticated(canPromptOnce: false, authed =>
+            {
+                if (!authed) return;
+
+                var client = PlayGamesPlatform.Instance.SavedGame;
+
+                client.OpenWithAutomaticConflictResolution(
+                    SLOT_NAME,
+                    DataSource.ReadCacheOrNetwork,
+                    ConflictResolutionStrategy.UseLongestPlaytime,
+                    (openStatus, meta) =>
+                    {
+                        if (openStatus != SavedGameRequestStatus.Success)
+                        {
+                            UnityEngine.Debug.LogError("[Save Controller] Cloud Open(write) failed: " + openStatus);
+                            return;
+                        }
+
+                        try
+                        {
+                            // Serialize + encrypt before upload
+                            globalSave.Flush(true);
+                            fsSerializer serializer = new fsSerializer();
+                            serializer.TrySerialize(globalSave, out fsData serializedData).AssertSuccessWithoutWarnings();
+                            string json = fsJsonPrinter.CompressedJson(serializedData);
+
+                            var uid = GetCloudUserId(PlayGamesPlatform.Instance?.localUser);
+                            if (!string.IsNullOrEmpty(uid))
+                            {
+                                json = SaveCrypto.EncryptJson(json, uid);
+                            }
+
+                            byte[] bytes = Encoding.UTF8.GetBytes(json);
+
+                            // Metadata update
+                            var builder = new SavedGameMetadataUpdate.Builder()
+                                .WithUpdatedDescription("Updated: " + DateTime.UtcNow.ToString("u"));
+
+                            // Optional: isi played time (jika ada GameTime dalam detik)
+                            try
+                            {
+                                var seconds = Math.Max(0, (int)globalSave.GameTime);
+                                builder = builder.WithUpdatedPlayedTime(TimeSpan.FromSeconds(seconds));
+                            }
+                            catch { /* ignore */ }
+
+                            var update = builder.Build();
+
+
+                            client.CommitUpdate(
+                                meta,
+                                update,
+                                bytes,
+                                (commitStatus, committedMeta) =>
+                                {
+                                    Debug.Log("[Save Controller] Cloud Commit: " + commitStatus);
+                                });
+                        }
+                        catch (Exception e)
+                        {
+                            Debug.LogError("[Save Controller] Cloud Serialize failed: " + e.Message);
+                        }
+                    });
+            });
+#endif
+        }
+
+#if UNITY_ANDROID 
+        private static void EnsureActivated()
+        {
+            PlayGamesPlatform.Activate();
+        }
+
+        /// <summary>
+        /// Coba silent sign-in dulu. Kalau gagal dan canPromptOnce=true, baru prompt sekali.
+        /// </summary>
+        private static void EnsureAuthenticated(bool canPromptOnce, Action<bool> onResult)
+        {
+            var pgp = PlayGamesPlatform.Instance;
+            bool IsAuthed()
+            {
+                try { return pgp?.localUser is { authenticated: true }; }
+                catch { return false; }
+            }
+
+            if (IsAuthed())
+            {
+                onResult?.Invoke(true);
+                return;
+            }
+
+            // Silent first
+            pgp.Authenticate(status =>
+            {
+                if (status == SignInStatus.Success || IsAuthed())
+                {
+                    onResult?.Invoke(true);
+                }
+                else if (canPromptOnce)
+                {
+                    pgp.Authenticate(promptStatus =>
+                    {
+                        onResult?.Invoke(promptStatus == SignInStatus.Success || IsAuthed());
+                    });
+                }
+                else
+                {
+                    onResult?.Invoke(false);
+                }
+            });
+        }
+
+        private static string GetCloudUserId(ILocalUser user)
+        {
+            if (user == null) return null;
+
+            try
+            {
+                if (!string.IsNullOrEmpty(user.id))
+                    return user.id;
+            }
+            catch { }
+
+            try
+            {
+                if (!string.IsNullOrEmpty(user.userName))
+                    return user.userName;
+            }
+            catch { }
+
+            return null;
+        }
+#endif
+    }
+#endif

--- a/Packages/com.bumimobile.save/Runtime/Wrappers/AndroidSaveWrapper.cs
+++ b/Packages/com.bumimobile.save/Runtime/Wrappers/AndroidSaveWrapper.cs
@@ -7,7 +7,7 @@ using GooglePlayGames.BasicApi;
 using GooglePlayGames.BasicApi.SavedGame;
 using UnityEngine;
 using UnityEngine.SocialPlatforms;
-using Watermelon.Security;
+using BumiMobile.Security;
 
 namespace BumiMobile
 {

--- a/Packages/com.bumimobile.save/Runtime/Wrappers/AndroidSaveWrapper.cs.meta
+++ b/Packages/com.bumimobile.save/Runtime/Wrappers/AndroidSaveWrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 39b394e1554939b4d8ef7a72a09771e9

--- a/Packages/com.bumimobile.save/Runtime/Wrappers/BaseSaveWrapper.cs
+++ b/Packages/com.bumimobile.save/Runtime/Wrappers/BaseSaveWrapper.cs
@@ -1,4 +1,6 @@
-﻿namespace BumiMobile
+﻿using System;
+
+namespace BumiMobile
 {
     public abstract class BaseSaveWrapper
     {
@@ -7,14 +9,27 @@
             new DefaultSaveWrapper();
 #elif UNITY_WEBGL
             new WebGLSaveWrapper();
+#elif UNITY_ANDROID && BUMI_SAVE_CLOUD_GPGS
+            new AndroidSaveWrapper();
+#elif UNITY_ANDROID && BUMI_SAVE_CLOUD_FIREBASE
+            new FirebaseSaveWrapper();
 #else
             new DefaultSaveWrapper();
 #endif
-
+        public virtual bool SupportsCloud => false;
         public abstract GlobalSave Load(string fileName);
         public abstract void Save(GlobalSave globalSave, string fileName);
         public abstract void Delete(string fileName);
 
         public virtual bool UseThreads() { return false; }
+        public virtual void BeginCloudLoad(Action<GlobalSave> onLoaded)
+        {
+            onLoaded?.Invoke(null);
+        }
+
+        public virtual void SaveCloud(GlobalSave globalSave)
+        {
+            /* no-op */
+        }
     }
 }

--- a/Packages/com.bumimobile.save/Runtime/Wrappers/FirebaseSaveWrapper.cs
+++ b/Packages/com.bumimobile.save/Runtime/Wrappers/FirebaseSaveWrapper.cs
@@ -1,0 +1,517 @@
+﻿#if BUMI_SAVE_CLOUD_FIREBASE
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Firebase;
+using Firebase.Auth;
+using Firebase.Firestore;
+using Firebase.Extensions;
+using FullSerializer;
+using UnityEngine;
+using BumiMobile.Security;
+
+namespace BumiMobile
+{
+    /// <summary>
+    /// FirebaseSaveWrapper (cloud enabled): Local + Firestore sync.
+    /// Layout Firestore (simplified):
+    ///   players/{uid}
+    /// Fields: json (string), updatedAt (Timestamp), version (int), clientTime (string ISO)
+    /// Conflict: newest updatedAt wins (server vs local). Debounced uploads.
+    /// </summary>
+    public sealed class FirebaseSaveWrapper : BaseSaveWrapper
+    {
+        const string COL_PLAYERS = "players"; // root collection
+        const string SUBCOL_SAVES = "saves";   // per-ISaveObject subcollection
+        const string SLOT_NAME = "main";       // local file name
+
+        readonly DefaultSaveWrapper _local = new DefaultSaveWrapper();
+        static FirebaseAuth _auth;
+        static FirebaseFirestore _fs;
+        static bool _available;              // True when dependencies + auth + firestore ready
+        static bool _pendingUpload;          // Flag for delayed push
+        static GlobalSave _queuedSave;       // Last save waiting to upload
+        static double _nextUploadAt;         // Stopwatch seconds when push should occur
+        const double UPLOAD_DEBOUNCE = 1.5d; // seconds
+        static readonly Stopwatch _watch = Stopwatch.StartNew();
+
+        // Async init control
+        static bool _initStarted;
+        static Task _initTask;
+        static readonly SemaphoreSlim _initLock = new SemaphoreSlim(1, 1);
+
+        public override bool SupportsCloud => true;
+
+        // Public-ish internal: ensure everything ready (dependencies + anon auth)
+        async Task EnsureInitializedAsync()
+        {
+            if (_available) return;
+            if (_initStarted)
+            {
+                if (_initTask != null) await _initTask;
+                return;
+            }
+
+            await _initLock.WaitAsync();
+            try
+            {
+                if (_available) return;
+                if (_initStarted && _initTask != null)
+                {
+                    await _initTask;
+                    return;
+                }
+                _initStarted = true;
+                _initTask = InternalInitAsync();
+            }
+            finally
+            {
+                _initLock.Release();
+            }
+
+            await _initTask;
+        }
+
+        static async Task InternalInitAsync()
+        {
+            try
+            {
+                // Respect persistent auth opt-out
+                if (UnityEngine.PlayerPrefs.GetInt("__auth_disabled__", 0) == 1)
+                {
+                    _available = false;
+                    UnityEngine.Debug.Log("[SaveCloud] Auth disabled by user. Skipping Firebase init.");
+                    return;
+                }
+
+                UnityEngine.Debug.Log("[SaveCloud] Init: checking Firebase dependencies...");
+                var status = await FirebaseApp.CheckAndFixDependenciesAsync();
+                if (status != DependencyStatus.Available)
+                {
+                    UnityEngine.Debug.LogWarning("[SaveCloud] Dependencies not available: " + status);
+                    _available = false;
+                    return;
+                }
+
+                _auth = FirebaseAuth.DefaultInstance;
+                if (_auth == null)
+                {
+                    UnityEngine.Debug.LogWarning("[SaveCloud] FirebaseAuth DefaultInstance null");
+                    _available = false;
+                    return;
+                }
+
+                if (_auth.CurrentUser == null)
+                {
+                    UnityEngine.Debug.Log("[SaveCloud] No user. Trying anonymous sign-in...");
+                    try
+                    {
+                        await _auth.SignInAnonymouslyAsync();
+                        if (_auth.CurrentUser != null)
+                            UnityEngine.Debug.Log("[SaveCloud] Anonymous sign-in success (uid=" + _auth.CurrentUser.UserId + ")");
+                        else
+                            UnityEngine.Debug.LogWarning("[SaveCloud] Anonymous sign-in returned null user");
+                    }
+                    catch (Exception e)
+                    {
+                        UnityEngine.Debug.LogWarning("[SaveCloud] Anonymous sign-in failed: " + e.Message);
+                        _available = false;
+                        return;
+                    }
+                }
+
+                try
+                {
+                    _fs = FirebaseFirestore.DefaultInstance;
+                }
+                catch (Exception fe)
+                {
+                    UnityEngine.Debug.LogWarning("[SaveCloud] Firestore init failed: " + fe.Message);
+                    _available = false;
+                    return;
+                }
+
+                _available = true;
+                UnityEngine.Debug.Log("[SaveCloud] Init complete (uid=" + (_auth.CurrentUser?.UserId ?? "null") + ")");
+            }
+            catch (Exception e)
+            {
+                _available = false;
+                UnityEngine.Debug.LogWarning("[SaveCloud] Init exception: " + e.Message);
+            }
+        }
+
+        async Task<FirebaseUser> GetUserAsync()
+        {
+            await EnsureInitializedAsync();
+            if (!_available) return null;
+            return _auth?.CurrentUser;
+        }
+
+        DocumentReference GetDoc(FirebaseUser user)
+        {
+            return _fs.Collection(COL_PLAYERS).Document(user.UserId);
+        }
+
+        public override GlobalSave Load(string fileName) => _local.Load(fileName);
+
+        public override void Save(GlobalSave globalSave, string fileName)
+        {
+            _local.Save(globalSave, fileName);
+            QueueUpload(globalSave);
+        }
+
+        public override void Delete(string fileName)
+        {
+            _local.Delete(fileName);
+            _ = DeleteRemoteAsync();
+        }
+
+        // async Task DeleteRemoteAsync() { }
+
+        public override bool UseThreads() => _local.UseThreads();
+
+        // async Task TryPushAsync(GlobalSave global) { }
+
+        public override void BeginCloudLoad(Action<GlobalSave> onLoaded)
+        {
+            _ = BeginCloudLoadAsync(onLoaded);
+        }
+
+        async Task BeginCloudLoadAsync(Action<GlobalSave> onLoaded)
+        {
+            await EnsureInitializedAsync();
+            if (!_available)
+            {
+                onLoaded?.Invoke(null);
+                return;
+            }
+            var user = await GetUserAsync();
+            if (user == null)
+            {
+                onLoaded?.Invoke(null);
+                return;
+            }
+            GlobalSave local = _local.Load(SLOT_NAME);
+            try
+            {
+                var docRef = GetDoc(user);
+                var snap = await docRef.GetSnapshotAsync();
+                if (!snap.Exists)
+                {
+                    UnityEngine.Debug.Log("[SaveCloud] No remote player doc, keeping local.");
+                    onLoaded?.Invoke(null);
+                    return;
+                }
+                // 1) Try read per-ISaveObject split from subcollection
+                var subCol = await docRef.Collection(SUBCOL_SAVES).GetSnapshotAsync();
+
+                // 2) Also try aggregated JSON (backward-compat)
+                GlobalSave aggregated = null;
+                if (snap.TryGetValue("json", out string aggJsonStr) && !string.IsNullOrEmpty(aggJsonStr))
+                {
+                    try
+                    {
+                        string plain = SaveCrypto.DecryptJsonIfNeeded(aggJsonStr, user.UserId);
+                        aggregated = Deserialize(plain);
+                    }
+                    catch (Exception decEx)
+                    {
+                        UnityEngine.Debug.LogWarning("[SaveCloud] Decrypt(aggregated) failed: " + decEx.Message);
+                    }
+                }
+
+                if (subCol != null && subCol.Count > 0)
+                {
+                    // Build containers from split docs
+                    var items = new List<(int hash, string json)>();
+                    foreach (var doc in subCol.Documents)
+                    {
+                        try
+                        {
+                            if (!int.TryParse(doc.Id, out int hash)) continue;
+                            if (!doc.TryGetValue("json", out string enc)) continue;
+                            string plain = SaveCrypto.DecryptJsonIfNeeded(enc, user.UserId);
+                            items.Add((hash, plain));
+                        }
+                        catch (Exception e)
+                        {
+                            UnityEngine.Debug.LogWarning("[SaveCloud] Sub save parse failed: " + e.Message);
+                        }
+                    }
+
+                    if (items.Count > 0)
+                    {
+                        var baseGlobal = aggregated ?? new GlobalSave();
+                        var rebuilt = BuildGlobalFromContainers(baseGlobal, items);
+                        onLoaded?.Invoke(rebuilt);
+                        return;
+                    }
+                }
+
+                if (aggregated != null)
+                {
+                    // Fallback to old single JSON
+                    onLoaded?.Invoke(aggregated);
+                    return;
+                }
+
+                // No usable remote data
+                onLoaded?.Invoke(null);
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning("[SaveCloud] Cloud load failed: " + e.Message);
+                onLoaded?.Invoke(null);
+            }
+        }
+
+        public override void SaveCloud(GlobalSave globalSave)
+        {
+            QueueUpload(globalSave);
+        }
+
+        void QueueUpload(GlobalSave save)
+        {
+            _queuedSave = save;
+            _pendingUpload = true;
+            _nextUploadAt = _watch.Elapsed.TotalSeconds + UPLOAD_DEBOUNCE;
+            if (!_uploadLoopRunning) _ = UploadLoop();
+        }
+
+        static bool _uploadLoopRunning;
+        async Task UploadLoop()
+        {
+            if (_uploadLoopRunning) return;
+            _uploadLoopRunning = true;
+            try
+            {
+                while (_pendingUpload)
+                {
+                    if (_watch.Elapsed.TotalSeconds < _nextUploadAt)
+                    {
+                        await Task.Delay(200);
+                        continue;
+                    }
+                    _pendingUpload = false;
+                    var toSend = _queuedSave;
+                    await EnsureInitializedAsync();
+                    if (!_available || toSend == null) continue;
+                    var user = _auth?.CurrentUser;
+                    if (user == null)
+                    {
+                        UnityEngine.Debug.LogWarning("[SaveCloud] Upload skipped, no user.");
+                        continue;
+                    }
+                    var uid = GetUserId(user);
+                    try
+                    {
+                        var docRef = GetDoc(user);
+
+                        // Root (meta) payload — encrypt when UID available
+                        string aggregatedJson = Serialize(toSend);
+                        aggregatedJson = EncryptForUser(aggregatedJson, uid, logMissingUid: true);
+
+                        var batch = _fs.StartBatch();
+
+                        var root = new Dictionary<string, object>
+                        {
+                            {"json", aggregatedJson},
+                            {"updatedAt", Timestamp.GetCurrentTimestamp()},
+                            {"version", 1},
+                            {"clientTime", DateTime.UtcNow.ToString("o")}
+                        };
+                        batch.Set(docRef, root, SetOptions.MergeAll);
+
+                        // Split per-ISaveObject (encrypt per container when possible)
+                        foreach (var item in EnumerateContainers(toSend))
+                        {
+                            try
+                            {
+                                string enc = item.json ?? string.Empty;
+                                enc = EncryptForUser(enc, uid, logMissingUid: false);
+                                var savePayload = new Dictionary<string, object>
+                                {
+                                    {"json", enc},
+                                    {"updatedAt", Timestamp.GetCurrentTimestamp()},
+                                    {"version", 1}
+                                };
+                                var subRef = docRef.Collection(SUBCOL_SAVES).Document(item.hash.ToString());
+                                batch.Set(subRef, savePayload, SetOptions.MergeAll);
+                            }
+                            catch (Exception encOne)
+                            {
+                                UnityEngine.Debug.LogWarning($"[SaveCloud] Per-item save failed (hash={item.hash}): " + encOne.Message);
+                            }
+                        }
+
+                        await batch.CommitAsync();
+                        UnityEngine.Debug.Log("[SaveCloud] Upload success (split).");
+                    }
+                    catch (Exception e)
+                    {
+                        UnityEngine.Debug.LogWarning("[SaveCloud] Upload failed: " + e.Message);
+                    }
+                }
+            }
+            finally
+            {
+                _uploadLoopRunning = false;
+            }
+        }
+
+        async Task DeleteRemoteAsync()
+        {
+            await EnsureInitializedAsync();
+            if (!_available) return;
+            var user = _auth?.CurrentUser;
+            if (user == null) return;
+            try
+            {
+                await GetDoc(user).DeleteAsync();
+                UnityEngine.Debug.Log("[SaveCloud] Remote delete success.");
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning("[SaveCloud] Remote delete failed: " + e.Message);
+            }
+        }
+
+        static string GetUserId(FirebaseUser user)
+        {
+            if (user == null) return null;
+            var uid = user.UserId;
+            if (string.IsNullOrEmpty(uid))
+            {
+                UnityEngine.Debug.LogWarning("[SaveCloud] Firebase user missing UserId.");
+                return null;
+            }
+            return uid;
+        }
+
+        static string EncryptForUser(string json, string uid, bool logMissingUid)
+        {
+            if (string.IsNullOrEmpty(json))
+                return json ?? string.Empty;
+
+            if (string.IsNullOrEmpty(uid))
+            {
+                if (logMissingUid)
+                    UnityEngine.Debug.LogWarning("[SaveCloud] Skip encryption: missing UID.");
+                return json;
+            }
+
+            try
+            {
+                return SaveCrypto.EncryptJson(json, uid);
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning("[SaveCloud] Encrypt failed: " + e.Message);
+                return json;
+            }
+        }
+
+        // ===== Serialization Helpers ========================================
+        static readonly fsSerializer _serializer = new fsSerializer();
+
+        static string Serialize(GlobalSave save)
+        {
+            var data = new fsData();
+            _serializer.TrySerialize(save.GetType(), save, out data).AssertSuccessWithoutWarnings();
+            return fsJsonPrinter.CompressedJson(data);
+        }
+
+        static GlobalSave Deserialize(string json)
+        {
+            try
+            {
+                var data = fsJsonParser.Parse(json);
+                object result = null;
+                _serializer.TryDeserialize(data, typeof(GlobalSave), ref result).AssertSuccessWithoutWarnings();
+                return result as GlobalSave;
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning("[SaveCloud] Deserialize failed: " + e.Message);
+                return null;
+            }
+        }
+
+        // ===== Reflection helpers to split/restore per ISaveObject ==========
+        static IEnumerable<(int hash, string json)> EnumerateContainers(GlobalSave save)
+        {
+            if (save == null) yield break;
+
+            var tGlobal = typeof(GlobalSave);
+            var fArray = tGlobal.GetField("saveObjects", BindingFlags.Instance | BindingFlags.NonPublic);
+            var fList = tGlobal.GetField("saveObjectsList", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            IEnumerable<object> containers = null;
+            if (fArray?.GetValue(save) is Array arr && arr.Length > 0)
+            {
+                var list = new List<object>();
+                foreach (var it in arr) list.Add(it);
+                containers = list;
+            }
+            else if (fList?.GetValue(save) is System.Collections.IEnumerable listEnum)
+            {
+                var list = new List<object>();
+                foreach (var it in listEnum) list.Add(it);
+                containers = list;
+            }
+
+            if (containers == null) yield break;
+
+            var tContainer = typeof(SavedDataContainer);
+            var fHash = tContainer.GetField("hash", BindingFlags.Instance | BindingFlags.NonPublic);
+            var fJson = tContainer.GetField("json", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            foreach (var c in containers)
+            {
+                if (c == null) continue;
+                int hash = 0;
+                string json = null;
+                try
+                {
+                    if (fHash != null) hash = (int)fHash.GetValue(c);
+                    if (fJson != null) json = (string)fJson.GetValue(c);
+                }
+                catch { /* ignore container if reflection fails */ }
+                yield return (hash, json ?? string.Empty);
+            }
+        }
+
+        static GlobalSave BuildGlobalFromContainers(GlobalSave baseGlobal, List<(int hash, string json)> items)
+        {
+            var result = baseGlobal ?? new GlobalSave();
+
+            var tContainer = typeof(SavedDataContainer);
+            var fHash = tContainer.GetField("hash", BindingFlags.Instance | BindingFlags.NonPublic);
+            var fJson = tContainer.GetField("json", BindingFlags.Instance | BindingFlags.NonPublic);
+            var fRestored = tContainer.GetProperty("Restored");
+
+            var containers = new SavedDataContainer[items.Count];
+            for (int i = 0; i < items.Count; i++)
+            {
+                var tuple = items[i];
+                var inst = (SavedDataContainer)FormatterServices.GetUninitializedObject(tContainer);
+                try { fHash?.SetValue(inst, tuple.hash); } catch { }
+                try { fJson?.SetValue(inst, tuple.json ?? string.Empty); } catch { }
+                try { fRestored?.SetValue(inst, false, null); } catch { }
+                containers[i] = inst;
+            }
+
+            var tGlobal = typeof(GlobalSave);
+            var fArray = tGlobal.GetField("saveObjects", BindingFlags.Instance | BindingFlags.NonPublic);
+            fArray?.SetValue(result, containers);
+
+            return result;
+        }
+    }
+}
+#endif

--- a/Packages/com.bumimobile.save/Runtime/Wrappers/FirebaseSaveWrapper.cs.meta
+++ b/Packages/com.bumimobile.save/Runtime/Wrappers/FirebaseSaveWrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dc408332b9cf73944aabd28416f3b628

--- a/Packages/com.bumimobile.save/Runtime/Wrappers/FirebaseSaveWrapperDisabled.cs
+++ b/Packages/com.bumimobile.save/Runtime/Wrappers/FirebaseSaveWrapperDisabled.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace BumiMobile
+{
+    // Stub save wrapper used when Firestore is temporarily disabled
+    public sealed class FirebaseSaveWrapperDisabled : BaseSaveWrapper
+    {
+        private readonly DefaultSaveWrapper _local = new DefaultSaveWrapper();
+
+        public override bool SupportsCloud => false;
+
+        public override GlobalSave Load(string fileName) => _local.Load(fileName);
+        public override void Save(GlobalSave globalSave, string fileName) => _local.Save(globalSave, fileName);
+        public override void Delete(string fileName) => _local.Delete(fileName);
+
+        public override bool UseThreads() => _local.UseThreads();
+
+        public override void BeginCloudLoad(Action<GlobalSave> onLoaded)
+        {
+            onLoaded?.Invoke(null); // no cloud when disabled
+        }
+
+        public override void SaveCloud(GlobalSave globalSave)
+        {
+            // no-op while cloud is disabled
+        }
+    }
+}
+

--- a/Packages/com.bumimobile.save/Runtime/Wrappers/FirebaseSaveWrapperDisabled.cs.meta
+++ b/Packages/com.bumimobile.save/Runtime/Wrappers/FirebaseSaveWrapperDisabled.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ccf3ad02e52f6c4bb49fa488d50496c

--- a/Packages/com.bumimobile.save/package.json
+++ b/Packages/com.bumimobile.save/package.json
@@ -11,6 +11,8 @@
   ],
   "category": "Framework",
   "dependencies": {
-    "com.bumimobile.core": "0.1.1"
+    "com.bumimobile.core": "0.1.1",
+    "com.bumimobile.fullserializer": "0.1.0",
+    "com.bumimobile.security": "0.1.0"
   }
 }

--- a/Packages/com.bumimobile.save/package.json
+++ b/Packages/com.bumimobile.save/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.save",
   "displayName": "Bumi Mobile Save",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "unity": "2021.3",
   "description": "Save system, serializers, and storage helpers for Bumi Mobile projects.",
   "keywords": [

--- a/Packages/com.bumimobile.security/CHANGELOG.md
+++ b/Packages/com.bumimobile.security/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+- (Add unreleased changes here)
+
+## [0.1.0] - 2025-12-02
+
+### Added
+
+- Initial release of the Security module with AES-256 + HMAC-SHA256 save encryption via `SaveCrypto`.
+- Editor utility to generate a per-project `SaveCryptoConfig` containing a unique `AppSecret`.

--- a/Packages/com.bumimobile.security/CHANGELOG.md.meta
+++ b/Packages/com.bumimobile.security/CHANGELOG.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
+guid: ed983da4d5ce63149ae56bcf87eaa9a0
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Packages/com.bumimobile.security/Editor.meta
+++ b/Packages/com.bumimobile.security/Editor.meta
@@ -1,6 +1,7 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
-TextScriptImporter:
+guid: 6e0ed0b767cac5d44bc42a155b856132
+folderAsset: yes
+DefaultImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Packages/com.bumimobile.security/Editor/SaveCryptoConfigGenerator.cs
+++ b/Packages/com.bumimobile.security/Editor/SaveCryptoConfigGenerator.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace BumiMobile.Security.Editor
+{
+    public static class SaveCryptoConfigGenerator
+    {
+        private const string ConfigPath = "Assets/Project Files/Game/Scripts/Security/SaveCryptoConfig.cs";
+
+        [MenuItem("Tools/Security/Generate SaveCryptoConfig")]
+        public static void Generate()
+        {
+            if (!EditorUtility.DisplayDialog("Generate SaveCryptoConfig",
+                "This will create/update a local SaveCryptoConfig.cs containing your AppSecret (NOT committed). Continue?",
+                "Yes", "No")) return;
+
+            string secret = System.Guid.NewGuid().ToString("N") + System.Guid.NewGuid().ToString("N");
+            string dir = Path.GetDirectoryName(ConfigPath);
+            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+
+            string code = "// AUTO-GENERATED. DO NOT COMMIT.\n" +
+                         "namespace Watermelon.Security { public static class SaveCryptoConfig { public static readonly string AppSecret = \"" + secret + "\"; } }\n";
+
+            File.WriteAllText(ConfigPath, code);
+            AssetDatabase.Refresh();
+            Debug.Log("[SaveCrypto] SaveCryptoConfig.cs generated at: " + ConfigPath);
+        }
+    }
+}

--- a/Packages/com.bumimobile.security/Editor/SaveCryptoConfigGenerator.cs
+++ b/Packages/com.bumimobile.security/Editor/SaveCryptoConfigGenerator.cs
@@ -20,7 +20,7 @@ namespace BumiMobile.Security.Editor
             if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
 
             string code = "// AUTO-GENERATED. DO NOT COMMIT.\n" +
-                         "namespace Watermelon.Security { public static class SaveCryptoConfig { public static readonly string AppSecret = \"" + secret + "\"; } }\n";
+                         "namespace BumiMobile.Security { public static class SaveCryptoConfig { public static readonly string AppSecret = \"" + secret + "\"; } }\n";
 
             File.WriteAllText(ConfigPath, code);
             AssetDatabase.Refresh();

--- a/Packages/com.bumimobile.security/Editor/SaveCryptoConfigGenerator.cs.meta
+++ b/Packages/com.bumimobile.security/Editor/SaveCryptoConfigGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 321571c3e02b49241908fa8cc6161a78

--- a/Packages/com.bumimobile.security/README.md
+++ b/Packages/com.bumimobile.security/README.md
@@ -1,0 +1,53 @@
+# Bumi Mobile Security
+
+Encryption helpers and editor tooling that keep Bumi Mobile save data tamper-resistant without burdening individual games. The module currently focuses on AES-256 encryption with HMAC verification via `SaveCrypto`.
+
+## Features
+
+- **Encrypted saves**: `SaveCrypto.EncryptJson`/`DecryptJsonIfNeeded` wrap JSON payloads before they hit disk. Data is AES-CBC encrypted and tagged with an HMAC-SHA256 signature to detect tampering.
+- **Per-install secrets**: Uses a generated `SaveCryptoConfig` (unique per project) combined with the player UID to derive independent encryption + MAC keys via PBKDF2.
+- **Version tagging**: Encrypted blobs are prefixed with `enc1:`. Legacy plaintext saves keep working—the decrypt helper simply returns the original string when the prefix is absent.
+- **Editor generator**: `Tools ▸ Security ▸ Generate SaveCryptoConfig` emits a local `SaveCryptoConfig.cs` (not committed) with a random `AppSecret`. Regenerate when starting a new project or rotating secrets.
+- **Secure defaults**: Uses 10k PBKDF2 iterations, zeroizes temporary key buffers, and avoids timing attacks via constant-time comparisons.
+
+## Requirements
+
+- Unity **2021.3** or newer.
+- `com.bumimobile.core` 0.1.1+ (for shared utilities and module registration).
+
+## Getting Started
+
+1. **Generate the config**
+
+   - In the Unity editor choose `Tools ▸ Security ▸ Generate SaveCryptoConfig`.
+   - A file at `Assets/Project Files/Game/Scripts/Security/SaveCryptoConfig.cs` is created with a random `AppSecret`. Keep it out of source control; regenerate for each project/environment.
+
+2. **Encrypt saves**
+
+```csharp
+string uid = playerProfile.UserId; // stable identifier per user
+string json = JsonUtility.ToJson(saveData);
+string encrypted = SaveCrypto.EncryptJson(json, uid);
+SaveToDisk(encrypted);
+```
+
+3. **Decrypt when loading**
+
+```csharp
+string raw = LoadFromDisk();
+string json = SaveCrypto.DecryptJsonIfNeeded(raw, uid);
+var saveData = JsonUtility.FromJson<MySaveData>(json);
+```
+
+- If the stored value is plaintext, `DecryptJsonIfNeeded` simply returns it—useful when upgrading legacy saves.
+- Corrupted or tampered data throws `CryptographicException`; catch it to trigger fallback flows or wipe invalid saves.
+
+## Tips
+
+- Rotate the `AppSecret` only when you plan to invalidate existing saves (you will not be able to decrypt older data).
+- Always pass a non-empty, stable `uid`—a device ID or authenticated user ID works best.
+- Consider storing the generated `SaveCryptoConfig.cs` outside version control (e.g., gitignore the folder) to prevent leaking secrets.
+
+## License
+
+Refer to the repository root `LICENSE` for licensing terms.

--- a/Packages/com.bumimobile.security/README.md.meta
+++ b/Packages/com.bumimobile.security/README.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
+guid: 61c42d05d708c6543b35f249fb2e19e8
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/Packages/com.bumimobile.security/Runtime.meta
+++ b/Packages/com.bumimobile.security/Runtime.meta
@@ -1,6 +1,7 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
-TextScriptImporter:
+guid: 772d12b57f3b82d4b99c6dd546093506
+folderAsset: yes
+DefaultImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Packages/com.bumimobile.security/Runtime/BumiMobile.Security.asmdef
+++ b/Packages/com.bumimobile.security/Runtime/BumiMobile.Security.asmdef
@@ -1,0 +1,12 @@
+{
+  "name": "BumiMobile.Security",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "noEngineReferences": false
+}

--- a/Packages/com.bumimobile.security/Runtime/BumiMobile.Security.asmdef.meta
+++ b/Packages/com.bumimobile.security/Runtime/BumiMobile.Security.asmdef.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
-TextScriptImporter:
+guid: 95a715b54f17d5a45b388398e2e7e303
+AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Packages/com.bumimobile.security/Runtime/SaveCrypto.cs
+++ b/Packages/com.bumimobile.security/Runtime/SaveCrypto.cs
@@ -90,7 +90,7 @@ namespace BumiMobile.Security
                 // Try to locate SaveCryptoConfig.AppSecret via reflection to avoid hard dependency
                 foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
                 {
-                    var t = asm.GetType("Watermelon.Security.SaveCryptoConfig");
+                    var t = asm.GetType("BumiMobile.Security.SaveCryptoConfig");
                     if (t == null) continue;
                     var f = t.GetField("AppSecret", BindingFlags.Public | BindingFlags.Static);
                     if (f == null) continue;

--- a/Packages/com.bumimobile.security/Runtime/SaveCrypto.cs
+++ b/Packages/com.bumimobile.security/Runtime/SaveCrypto.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using UnityEngine;
+
+namespace BumiMobile.Security
+{
+    public static class SaveCrypto
+    {
+        // WARNING: For development only. Replace at build time by generating SaveCryptoConfig.cs
+        private const string DevFallbackSecret = "dev-fallback-secret-DO-NOT-USE-IN-PROD";
+        private const string Prefix = "enc1:"; // version tag
+
+        public static string EncryptJson(string json, string uid)
+        {
+            if (string.IsNullOrEmpty(json)) return json;
+            if (string.IsNullOrEmpty(uid)) throw new ArgumentException("UID required for encryption.");
+
+            DeriveKeys(uid, out var encKey, out var macKey);
+
+            byte[] iv = new byte[16];
+            RandomNumberGenerator.Fill(iv);
+
+            byte[] plain = Encoding.UTF8.GetBytes(json);
+            byte[] cipher = AesCbcEncrypt(plain, encKey, iv);
+
+            byte[] mac = HmacSha256(macKey, Concat(iv, cipher));
+
+            byte[] packed = Concat(Concat(iv, cipher), mac);
+            string b64 = Convert.ToBase64String(packed);
+
+            Clear(encKey); Clear(macKey); Clear(plain);
+            return Prefix + b64;
+        }
+
+        public static string DecryptJsonIfNeeded(string value, string uid)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+            if (!value.StartsWith(Prefix, StringComparison.Ordinal)) return value; // legacy plaintext
+            if (string.IsNullOrEmpty(uid)) throw new ArgumentException("UID required for decryption.");
+
+            string b64 = value.Substring(Prefix.Length);
+            byte[] packed = Convert.FromBase64String(b64);
+            if (packed.Length < 16 + 32) throw new CryptographicException("Cipher too short");
+
+            byte[] iv = new byte[16];
+            Buffer.BlockCopy(packed, 0, iv, 0, 16);
+
+            int macLen = 32;
+            int cipherLen = packed.Length - 16 - macLen;
+            if (cipherLen <= 0) throw new CryptographicException("Invalid cipher length");
+
+            byte[] cipher = new byte[cipherLen];
+            Buffer.BlockCopy(packed, 16, cipher, 0, cipherLen);
+
+            byte[] mac = new byte[macLen];
+            Buffer.BlockCopy(packed, 16 + cipherLen, mac, 0, macLen);
+
+            DeriveKeys(uid, out var encKey, out var macKey);
+
+            byte[] macCalc = HmacSha256(macKey, Concat(iv, cipher));
+            if (!FixedTimeEquals(mac, macCalc)) throw new CryptographicException("HMAC mismatch");
+
+            byte[] plain = AesCbcDecrypt(cipher, encKey, iv);
+            string json = Encoding.UTF8.GetString(plain);
+
+            Clear(encKey); Clear(macKey); Clear(plain);
+            return json;
+        }
+
+        // ===== helpers =====
+        private static void DeriveKeys(string uid, out byte[] encKey, out byte[] macKey)
+        {
+            byte[] appKey = GetAppKeyBytes();
+            byte[] salt = SHA256(uid);
+            using var kdf = new Rfc2898DeriveBytes(appKey, salt, 10000, HashAlgorithmName.SHA256);
+            byte[] key64 = kdf.GetBytes(64);
+            encKey = new byte[32];
+            macKey = new byte[32];
+            Buffer.BlockCopy(key64, 0, encKey, 0, 32);
+            Buffer.BlockCopy(key64, 32, macKey, 0, 32);
+            Clear(key64); Clear(appKey);
+        }
+
+        private static byte[] GetAppKeyBytes()
+        {
+            try
+            {
+                // Try to locate SaveCryptoConfig.AppSecret via reflection to avoid hard dependency
+                foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    var t = asm.GetType("Watermelon.Security.SaveCryptoConfig");
+                    if (t == null) continue;
+                    var f = t.GetField("AppSecret", BindingFlags.Public | BindingFlags.Static);
+                    if (f == null) continue;
+                    var secret = f.GetValue(null) as string;
+                    if (!string.IsNullOrEmpty(secret)) return SHA256(secret);
+                }
+                Debug.LogWarning("[SaveCrypto] Using DevFallbackSecret. Generate SaveCryptoConfig.cs for production builds.");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning("[SaveCrypto] Failed to fetch AppSecret via reflection: " + e.Message);
+            }
+            return SHA256(DevFallbackSecret);
+        }
+
+        private static byte[] AesCbcEncrypt(byte[] plain, byte[] key, byte[] iv)
+        {
+            using var aes = Aes.Create();
+            aes.Mode = CipherMode.CBC;
+            aes.Padding = PaddingMode.PKCS7;
+            aes.Key = key;
+            aes.IV = iv;
+            using var enc = aes.CreateEncryptor();
+            return enc.TransformFinalBlock(plain, 0, plain.Length);
+        }
+
+        private static byte[] AesCbcDecrypt(byte[] cipher, byte[] key, byte[] iv)
+        {
+            using var aes = Aes.Create();
+            aes.Mode = CipherMode.CBC;
+            aes.Padding = PaddingMode.PKCS7;
+            aes.Key = key;
+            aes.IV = iv;
+            using var dec = aes.CreateDecryptor();
+            return dec.TransformFinalBlock(cipher, 0, cipher.Length);
+        }
+
+        private static byte[] HmacSha256(byte[] key, byte[] data)
+        {
+            using var h = new HMACSHA256(key);
+            return h.ComputeHash(data);
+        }
+
+        private static byte[] SHA256(string s)
+        {
+            using var sha = System.Security.Cryptography.SHA256.Create();
+            return sha.ComputeHash(Encoding.UTF8.GetBytes(s ?? string.Empty));
+        }
+
+        private static byte[] Concat(byte[] a, byte[] b)
+        {
+            byte[] r = new byte[a.Length + b.Length];
+            Buffer.BlockCopy(a, 0, r, 0, a.Length);
+            Buffer.BlockCopy(b, 0, r, a.Length, b.Length);
+            return r;
+        }
+
+        private static bool FixedTimeEquals(byte[] a, byte[] b)
+        {
+            if (a == null || b == null || a.Length != b.Length) return false;
+            int diff = 0;
+            for (int i = 0; i < a.Length; i++) diff |= a[i] ^ b[i];
+            return diff == 0;
+        }
+
+        private static void Clear(byte[] arr)
+        {
+            if (arr == null) return;
+            Array.Clear(arr, 0, arr.Length);
+        }
+    }
+}

--- a/Packages/com.bumimobile.security/Runtime/SaveCrypto.cs.meta
+++ b/Packages/com.bumimobile.security/Runtime/SaveCrypto.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ffdc73b50b5dad94a95ddfaf498ebffe

--- a/Packages/com.bumimobile.security/package.json
+++ b/Packages/com.bumimobile.security/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "com.bumimobile.security",
+  "displayName": "Bumi Mobile Security",
+  "version": "0.1.0",
+  "unity": "2021.3",
+  "description": "Security module for Bumi Mobile framework, providing features such as data encryption and secure storage.",
+  "keywords": [
+    "bumi",
+    "security",
+    "module"
+  ],
+  "category": "Security",
+  "dependencies": {
+    "com.bumimobile.core": "0.1.1"
+  }
+}

--- a/Packages/com.bumimobile.security/package.json.meta
+++ b/Packages/com.bumimobile.security/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 0a81d6417ad249a4fac209c945b9e6c0
-TextScriptImporter:
+guid: 95bcc83fa88bfc94a8f59c66b7e80432
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -41,6 +41,14 @@
         "com.bumimobile.core": "0.1.1"
       }
     },
+    "com.bumimobile.fullserializer": {
+      "version": "file:com.bumimobile.fullserializer",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {
+        "com.bumimobile.core": "0.1.1"
+      }
+    },
     "com.bumimobile.haptic": {
       "version": "file:com.bumimobile.haptic",
       "depth": 0,
@@ -106,6 +114,16 @@
     },
     "com.bumimobile.save": {
       "version": "file:com.bumimobile.save",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {
+        "com.bumimobile.core": "0.1.1",
+        "com.bumimobile.fullserializer": "0.1.0",
+        "com.bumimobile.security": "0.1.0"
+      }
+    },
+    "com.bumimobile.security": {
+      "version": "file:com.bumimobile.security",
       "depth": 0,
       "source": "embedded",
       "dependencies": {


### PR DESCRIPTION
This pull request introduces the new `com.bumimobile.fullserializer` Unity package, providing a standalone, Unity-ready version of FullSerializer for Bumi Mobile Core and related modules. It includes documentation, changelog, and the initial source code for AOT (Ahead-of-Time) serialization support, as well as supporting meta files for proper Unity package integration. Additionally, a minor naming update is made in the core editor settings.

**New FullSerializer package integration:**

* Added `README.md` and `CHANGELOG.md` for `com.bumimobile.fullserializer`, detailing features, usage, and release notes for the new package. [[1]](diffhunk://#diff-21a6a55506c44b4ad07a804a2fd8f8d3ab95c34d206a7ee5dba45d436f6e060cR1-R50) [[2]](diffhunk://#diff-547138e1ac477a297580bac0bdef4ec45ddd699c3cc1677c7c0240db699b4f85R1-R16)
* Introduced AOT serialization support with source files: `Source/Aot/fsAotCompilationManager.cs` and its Unity Editor integration in `Source/Aot/Editor/fsAotConfigurationEditor.cs`. These enable deterministic JSON serialization and custom converter generation for Unity types. [[1]](diffhunk://#diff-d7d48990f68fdd4562f97613e7ed711547f54ba8d181b9adec2f81c8e8e7203bR1-R154) [[2]](diffhunk://#diff-6b4967d879c448a2587953852ae4e43545cf111deacb2cf9c067d949da9c93edR1-R250)
* Included Unity `.meta` files for all new package assets and folders, ensuring correct import and asset management in the Unity editor. [[1]](diffhunk://#diff-d950956bf6301b72cc94877b7c2a8a257dd0db830fbd55b1242caac2c7226e03R1-R7) [[2]](diffhunk://#diff-2d1e3dc06bae3fcfc5907dfe39ad55f9515d38080bf4045b8f60b46e05dfa99bR1-R7) [[3]](diffhunk://#diff-42c9ef5aa909ffbd84eabc5de33ed1b2954091b54d44ccc8101eae4eb96f58b0R1-R8) [[4]](diffhunk://#diff-9029b4b51b383f7227525a96eda766ab12108b689052592a4bbe9c54ad95bbe0R1-R9) [[5]](diffhunk://#diff-df972c12553835c81a53eed83a0d944a310a6a2ecaaf5ca6a59bdfa902d0b618R1-R9) [[6]](diffhunk://#diff-4034a137641822a3a8be757d998e6cadf8d64b2a2fc4a3d1311c75d198037cbeR1-R2) [[7]](diffhunk://#diff-f6f076e3526ce64bcb09eaf5ee16431c8f13c1b1a622493adcf86a575ce2d11fR1-R12)

**Core settings update:**

* Renamed the `ShowWatermelonPromotions` property to `ShowBumiMobilePromotions` in `CoreEditor.cs` for improved clarity and branding consistency.