### PR TITLE
Fix : Reschudling notification

### DIFF
--- a/Packages/com.bumimobile.pushnotification/CHANGELOG.md
+++ b/Packages/com.bumimobile.pushnotification/CHANGELOG.md
@@ -8,6 +8,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 - (Add unreleased changes here)
 
+## [0.2.3] - 2025-12-08
+
+### Added
+
+- **Notification Deduplication System**: Automatically handles multiple notifications of the same type scheduled at the same time by randomly selecting one to display and rescheduling others for future days.
+  - Notifications within 5 minutes are considered duplicates
+  - Notifications 4+ hours apart are not deduplicated
+  - Duplicates are rescheduled with count-based day offsets (+1, +2, +3 days, etc.)
+  - Random selection ensures fair distribution across app sessions
+- New `enableDeduplication` configuration option in `NotificationSettings` to toggle the feature
+- Public API methods `SetDeduplicationEnabled()` and `IsDeduplicationEnabled()` for runtime control
+- Detailed logging of deduplication actions for debugging
+
+### Changed
+
+- `ScheduleAllNotifications` now collects all candidates before scheduling to enable deduplication processing
+
+
 ## [0.2.2] - 2025-11-20
 
 ### Added

--- a/Packages/com.bumimobile.pushnotification/README.md
+++ b/Packages/com.bumimobile.pushnotification/README.md
@@ -9,6 +9,7 @@ This package provides a simple, data-driven push notification solution for Bumi 
 - `NotificationTemplateCatalog` ScriptableObject that references the templates you create and exposes them to the scheduler.
 - `NotificationSettings` ScriptableObject that binds a catalog to the initialization pipeline and optionally auto-schedules.
 - `NotificationManager` runtime scheduler that enforces cooldowns, trigger constraints, and platform-specific delivery.
+- **Automatic deduplication** that handles multiple notifications of the same type scheduled at the same time by randomly selecting one and rescheduling others.
 
 ## Requirements
 
@@ -55,6 +56,34 @@ This package provides a simple, data-driven push notification solution for Bumi 
 - **Add new notification types:** Extend the `NotificationType` enum and update `NotificationTemplateDefaults.CreateRuntimeTemplates` inside `NotificationTemplate.cs` if you need new fallback defaults.
 - **Custom triggers:** Introduce new values in `NotificationTriggerType` and adjust `NotificationManager.DetermineSchedule` with the scheduling logic.
 - **Per-project customization:** Duplicate the built-in defaults by creating new `NotificationTemplate` assets (rules, messages, media) and adding them to your catalog.
+
+## Deduplication
+
+The package automatically handles duplicate notifications (multiple notifications of the same type scheduled at the same time):
+
+- **Same-time threshold:** Notifications within 5 minutes are considered duplicates.
+- **Minimum interval:** Notifications 4+ hours apart are not deduplicated.
+- **Random selection:** One notification is randomly chosen to stay at the original time.
+- **Sequential rescheduling:** Others are rescheduled to +1, +2, +3 days, etc.
+
+### Configuration
+
+Enable or disable deduplication in `NotificationSettings`:
+- Check/uncheck `Enable Deduplication` in the Inspector (default: enabled).
+
+Or control it via code:
+```csharp
+NotificationManager.SetDeduplicationEnabled(false);
+bool isEnabled = NotificationManager.IsDeduplicationEnabled();
+```
+
+### Example
+
+If 4 notifications of type `DailyRetention` are scheduled for 10:00 AM:
+- One stays at 10:00 AM (randomly selected)
+- Others rescheduled to 10:00 AM +1 day, +2 days, +3 days
+
+The system logs deduplication actions to help with debugging.
 
 ## Troubleshooting
 

--- a/Packages/com.bumimobile.pushnotification/Runtime/NotificationManager.cs
+++ b/Packages/com.bumimobile.pushnotification/Runtime/NotificationManager.cs
@@ -12,8 +12,12 @@ using Unity.Notifications.iOS;
 public static class NotificationManager
 {
     private const string DefaultChannelId = "default_channel";
+    private const int SameTimeThresholdMinutes = 5;
+    private const int MinimumIntervalHours = 4;
 
     private static NotificationTemplateCatalog _catalog;
+    private static bool _enableDeduplication = true;
+    private static System.Random _random = new System.Random();
 
     public static NotificationTemplateCatalog Catalog => LoadCatalog();
 
@@ -21,6 +25,16 @@ public static class NotificationManager
     {
         _catalog = customCatalog;
         _catalog?.RemoveNullEntries();
+    }
+
+    public static void SetDeduplicationEnabled(bool enabled)
+    {
+        _enableDeduplication = enabled;
+    }
+
+    public static bool IsDeduplicationEnabled()
+    {
+        return _enableDeduplication;
     }
 
     public static IReadOnlyList<ScheduledNotification> ScheduleAllNotifications(NotificationScheduleContext context = null)
@@ -36,7 +50,8 @@ public static class NotificationManager
             return Array.Empty<ScheduledNotification>();
         }
 
-        var scheduled = new List<ScheduledNotification>();
+        // First, collect ALL candidates
+        var allCandidates = new List<ScheduledNotification>();
         foreach (var template in catalog.Notifications)
         {
             if (template == null)
@@ -45,10 +60,23 @@ public static class NotificationManager
             }
             foreach (var candidate in DetermineSchedule(template, context))
             {
-                SchedulePlatformNotification(candidate);
-                scheduled.Add(candidate);
-                context.AppendHistory(candidate.Type, candidate.FireTime);
+                allCandidates.Add(candidate);
             }
+        }
+
+        // Apply deduplication if enabled
+        if (_enableDeduplication)
+        {
+            allCandidates = DeduplicateNotifications(allCandidates, context);
+        }
+
+        // Now schedule the deduplicated list
+        var scheduled = new List<ScheduledNotification>();
+        foreach (var candidate in allCandidates)
+        {
+            SchedulePlatformNotification(candidate);
+            scheduled.Add(candidate);
+            context.AppendHistory(candidate.Type, candidate.FireTime);
         }
 
         return scheduled;
@@ -244,6 +272,90 @@ public static class NotificationManager
 
                 break;
         }
+    }
+
+    private static List<ScheduledNotification> DeduplicateNotifications(
+        List<ScheduledNotification> candidates,
+        NotificationScheduleContext context)
+    {
+        if (candidates == null || candidates.Count == 0)
+        {
+            return candidates;
+        }
+
+        var result = new List<ScheduledNotification>();
+
+        // Group by notification type
+        var typeGroups = candidates.GroupBy(n => n.Type);
+
+        foreach (var typeGroup in typeGroups)
+        {
+            var notifications = typeGroup.OrderBy(n => n.FireTime).ToList();
+
+            // Process each notification
+            for (int i = 0; i < notifications.Count; i++)
+            {
+                var current = notifications[i];
+                var duplicates = new List<ScheduledNotification> { current };
+
+                // Find duplicates within the same time threshold
+                for (int j = i + 1; j < notifications.Count; j++)
+                {
+                    var next = notifications[j];
+                    var timeDiff = (next.FireTime - current.FireTime).TotalMinutes;
+
+                    // Check if notifications are at the same time (within threshold)
+                    if (timeDiff <= SameTimeThresholdMinutes)
+                    {
+                        duplicates.Add(next);
+                    }
+                    else if (timeDiff >= MinimumIntervalHours * 60)
+                    {
+                        // If this notification is 4+ hours away, stop checking
+                        break;
+                    }
+                }
+
+                // Handle duplicates
+                if (duplicates.Count > 1)
+                {
+                    // Randomly select one to keep at original time
+                    var selectedIndex = _random.Next(duplicates.Count);
+                    var selected = duplicates[selectedIndex];
+                    result.Add(selected);
+
+                    Debug.Log($"[NotificationManager] Found {duplicates.Count} duplicate {current.Type} notifications at {current.FireTime:yyyy-MM-dd HH:mm}. Selected notification at index {selectedIndex} to keep.");
+
+                    // Reschedule the rest
+                    var dayOffset = 1;
+                    for (int k = 0; k < duplicates.Count; k++)
+                    {
+                        if (k == selectedIndex)
+                        {
+                            continue; // Skip the selected one
+                        }
+
+                        var notification = duplicates[k];
+                        var newFireTime = notification.FireTime.AddDays(dayOffset);
+                        notification.FireTime = newFireTime;
+                        result.Add(notification);
+
+                        Debug.Log($"[NotificationManager] Rescheduled duplicate {notification.Type} to {newFireTime:yyyy-MM-dd HH:mm} (+{dayOffset} day{(dayOffset > 1 ? "s" : "")}).");
+                        dayOffset++;
+                    }
+
+                    // Skip the processed duplicates
+                    i += duplicates.Count - 1;
+                }
+                else
+                {
+                    // No duplicates, add as is
+                    result.Add(current);
+                }
+            }
+        }
+
+        return result;
     }
 
     private static NotificationTemplateCatalog LoadCatalog()

--- a/Packages/com.bumimobile.pushnotification/Runtime/NotificationSettings.cs
+++ b/Packages/com.bumimobile.pushnotification/Runtime/NotificationSettings.cs
@@ -19,12 +19,19 @@ public class NotificationSettings : ScriptableObject
     [Tooltip("Log a warning when no catalog is provided and the fallback defaults are used.")]
     private bool logMissingCatalogWarning = true;
 
+    [SerializeField]
+    [Tooltip("When multiple notifications of the same type are scheduled at the same time, randomly select one and reschedule others for future days.")]
+    private bool enableDeduplication = true;
+
     public NotificationTemplateCatalog TemplateCatalog => templateCatalog;
     public bool ScheduleOnInit => scheduleOnInit;
     public bool ScheduleInEditor => scheduleInEditor;
+    public bool EnableDeduplication => enableDeduplication;
 
     public void ApplyCatalog()
     {
+        NotificationManager.SetDeduplicationEnabled(enableDeduplication);
+
         if (templateCatalog != null)
         {
             NotificationManager.RegisterCatalog(templateCatalog);

--- a/Packages/com.bumimobile.pushnotification/package.json
+++ b/Packages/com.bumimobile.pushnotification/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.pushnotification",
   "displayName": "Bumi Mobile Push Notification",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "unity": "2021.3",
   "description": "Push notification manager and initializer for Bumi Mobile projects.",
   "keywords": [


### PR DESCRIPTION
This pull request introduces a notification deduplication system to the push notification package, enhancing how duplicate notifications are handled. The new system detects and manages multiple notifications of the same type scheduled for similar times, rescheduling duplicates and providing configurable options for developers. Documentation and public APIs have been updated to reflect these changes.

**Notification Deduplication System:**

- Added a deduplication mechanism that groups notifications of the same type scheduled within 5 minutes, randomly selects one to display, and reschedules the rest to future days (+1, +2, etc.). Notifications 4+ hours apart are not deduplicated. Debug logging provides visibility into deduplication actions. [[1]](diffhunk://#diff-a7120bb8cbee57a39679a23842148a9503f675bde7eea431fdf0e2dd432ceadfR277-R360) [[2]](diffhunk://#diff-f2731950ab5c688c869e9aa4100afbfc088eb9467b5ac025a8e876590e171c86R11-R28) [[3]](diffhunk://#diff-9e6b9300a66f86c0241339d8523483f1718db5510a976119a9c47749f75c3d37R12) [[4]](diffhunk://#diff-9e6b9300a66f86c0241339d8523483f1718db5510a976119a9c47749f75c3d37R60-R87)

**Configuration and API:**

- Introduced a new `enableDeduplication` field in `NotificationSettings` (ScriptableObject) with inspector UI and runtime getter. The setting is applied to `NotificationManager` on initialization.
- Added public API methods `SetDeduplicationEnabled()` and `IsDeduplicationEnabled()` to control deduplication at runtime.

**Scheduling Logic Changes:**

- Modified `ScheduleAllNotifications` to collect all notification candidates first, then apply deduplication before scheduling.

**Documentation Updates:**

- Updated `README.md` and `CHANGELOG.md` to document the deduplication feature, configuration options, and usage examples. [[1]](diffhunk://#diff-f2731950ab5c688c869e9aa4100afbfc088eb9467b5ac025a8e876590e171c86R11-R28) [[2]](diffhunk://#diff-9e6b9300a66f86c0241339d8523483f1718db5510a976119a9c47749f75c3d37R12) [[3]](diffhunk://#diff-9e6b9300a66f86c0241339d8523483f1718db5510a976119a9c47749f75c3d37R60-R87)

**Version Bump:**

- Updated package version to `0.2.3` to reflect the new feature.