### PR TITLE
fix(auth): sign in to existing account when Google credential already linked

### DIFF
--- a/Packages/com.bumimobile.auth/CHANGELOG.md
+++ b/Packages/com.bumimobile.auth/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.2] - 2026-05-29
 
 ### Changed
 
@@ -18,6 +18,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ### Fixed
 
+- Handle "credential already in use" error during `ManualSignInAsync`: when signing in with Google and the credential belongs to a different Firebase account, sign into that existing account instead of failing. Added `IsCredentialAlreadyInUseError` helper that recurses into `InnerException`.
 - `GetUserLabel()` now returns `"Guest {uid_prefix}"` for anonymous users instead of an empty string.
 - `CreateAnonymousAsync` now fires `OnPlatformAuthFinished(false)` to signal platform auth was skipped.
 - Added explicit-sign-out gate: if the user signs out via `SignOutAsync`, the next cold start skips silent Google Sign-In to prevent unwanted auto-re-authentication.

--- a/Packages/com.bumimobile.auth/Runtime/AuthService.cs
+++ b/Packages/com.bumimobile.auth/Runtime/AuthService.cs
@@ -399,11 +399,35 @@ namespace BumiMobile
 
                 if (auth.CurrentUser.IsAnonymous)
                 {
-                    await auth.CurrentUser.LinkWithCredentialAsync(cred);
-                    await auth.CurrentUser.ReloadAsync();
-                    User = auth.CurrentUser;
-                    OnFirebaseAuthChanged?.Invoke(User);
-                    return true;
+                    // await auth.CurrentUser.LinkWithCredentialAsync(cred);
+                    // await auth.CurrentUser.ReloadAsync();
+                    // User = auth.CurrentUser;
+                    // OnFirebaseAuthChanged?.Invoke(User);
+                    // return true;
+
+                    try
+                    {
+                        await auth.CurrentUser.LinkWithCredentialAsync(cred);
+                        await auth.CurrentUser.ReloadAsync();
+                        User = auth.CurrentUser;
+                        OnFirebaseAuthChanged?.Invoke(User);
+                        return true;
+                    }
+                    catch (Exception e) when (IsCredentialAlreadyInUseError(e))
+                    {
+                        // Credential already linked to a different Firebase account.
+                        // Sign into that existing account, discarding the anonymous one.
+                        Debug.Log("[Auth] Google credential already linked to another account. Signing into that account.");
+                        User = await auth.SignInWithCredentialAsync(cred);
+                        if (User != null)
+                        {
+                            OnFirebaseAuthChanged?.Invoke(User);
+                            return true;
+                        }
+
+                        LastAuthFailureReason = "[Auth] Sign-in to existing account returned null user.";
+                        return false;
+                    }
                 }
 
                 // IMPORTANT: When auth.CurrentUser is non-null AND non-anonymous,
@@ -481,6 +505,14 @@ namespace BumiMobile
                 PlayerPrefs.DeleteKey(PREF_USER_EXPLICITLY_SIGNED_OUT);
 
             PlayerPrefs.Save();
+        }
+
+        private static bool IsCredentialAlreadyInUseError(Exception e)
+        {
+            if (e == null) return false;
+            var msg = e.Message ?? string.Empty;
+            if (msg.Contains("already associated")) return true;
+            return IsCredentialAlreadyInUseError(e.InnerException);
         }
     }
 }

--- a/Packages/com.bumimobile.auth/package.json
+++ b/Packages/com.bumimobile.auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.auth",
   "displayName": "Bumi Mobile Auth",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "unity": "2021.3",
   "description": "Anonymous-first authentication for the Bumi Mobile framework. Auto-initialises Firebase (restore/anonymous), upgrades to Google-linked on manual sign-in.",
   "keywords": [


### PR DESCRIPTION
## Summary

When a user signs in with Google and the credential is already linked to a different Firebase account, LinkWithCredentialAsync throws an error. This PR handles that case gracefully by signing into the existing account instead of failing.

## Changes

### AuthService.cs
- Wrapped LinkWithCredentialAsync in a try/catch for credential-in-use errors
- On IsCredentialAlreadyInUseError — sign into the existing account via SignInWithCredentialAsync
- Added IsCredentialAlreadyInUseError helper that recursively walks the exception chain

### Package
- Bumped version to 0.2.2
- Updated changelog