### PR TITLE
fix(localization): update settings menu name

### DIFF
--- a/Packages/com.bumimobile.localization/CHANGELOG.md
+++ b/Packages/com.bumimobile.localization/CHANGELOG.md
@@ -8,6 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 - (Add unreleased changes here)
 
+## [0.1.4] - 2026-06-04
+
+### Changed
+
+- Updated the `LocalizationSettings` asset menu path to `Bumimobile/Localization Settings`.
+
 ## [0.1.3] - 2025-12-11
 
 ### Added

--- a/Packages/com.bumimobile.localization/CHANGELOG.md
+++ b/Packages/com.bumimobile.localization/CHANGELOG.md
@@ -12,7 +12,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ### Changed
 
-- Updated the `LocalizationSettings` asset menu path to `Bumimobile/Localization Settings`.
+- Updated the `LocalizationSettings` asset menu path to `BumiMobile/Localization Settings`.
 
 ## [0.1.3] - 2025-12-11
 

--- a/Packages/com.bumimobile.localization/Runtime/LocalizationSettings.cs
+++ b/Packages/com.bumimobile.localization/Runtime/LocalizationSettings.cs
@@ -17,7 +17,7 @@ using Unity.EditorCoroutines.Editor;
 
 namespace BumiMobile
 {
-    [CreateAssetMenu(fileName = "LocalizationSettings", menuName = "Bumimobile/Localization Settings")]
+    [CreateAssetMenu(fileName = "LocalizationSettings", menuName = "BumiMobile/Localization Settings")]
     public class LocalizationSettings : ScriptableObject
     {
         /// <summary>

--- a/Packages/com.bumimobile.localization/Runtime/LocalizationSettings.cs
+++ b/Packages/com.bumimobile.localization/Runtime/LocalizationSettings.cs
@@ -17,7 +17,7 @@ using Unity.EditorCoroutines.Editor;
 
 namespace BumiMobile
 {
-    [CreateAssetMenu(fileName = "LocalizationSettings", menuName = "Data/Simple Localization/Settings")]
+    [CreateAssetMenu(fileName = "LocalizationSettings", menuName = "Bumimobile/Localization Settings")]
     public class LocalizationSettings : ScriptableObject
     {
         /// <summary>
@@ -35,9 +35,9 @@ namespace BumiMobile
 
         public static DateTime Timestamp;
 
-        public static event Action OnRunEditor = () => {};
+        public static event Action OnRunEditor = () => { };
 
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
 
         public void Awake()
         {
@@ -51,7 +51,7 @@ namespace BumiMobile
         {
             EditorCoroutineUtility.StartCoroutineOwnerless(DownloadGoogleSheetsCoroutine(callback));
         }
-        
+
         public IEnumerator DownloadGoogleSheetsCoroutine(Action callback = null, bool silent = false)
         {
             if (string.IsNullOrEmpty(TableId) || Sheets.Count == 0)
@@ -79,7 +79,7 @@ namespace BumiMobile
                     yield break;
                 }
             }
-            
+
             Timestamp = DateTime.UtcNow;
 
             if (!silent) ClearSaveFolder();
@@ -92,7 +92,7 @@ namespace BumiMobile
                 Debug.Log($"Downloading <color=grey>{url}</color>");
 
                 var request = UnityWebRequest.Get(url);
-                var progress = (float) (i + 1) / Sheets.Count;
+                var progress = (float)(i + 1) / Sheets.Count;
 
                 if (EditorUtility.DisplayCancelableProgressBar("Downloading sheets...", $"[{(int)(100 * progress)}%] [{i + 1}/{Sheets.Count}] Downloading {sheet.Name}...", progress))
                 {
@@ -281,6 +281,6 @@ namespace BumiMobile
             }
         }
 
-        #endif
+#endif
     }
 }

--- a/Packages/com.bumimobile.localization/package.json
+++ b/Packages/com.bumimobile.localization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.localization",
   "displayName": "Bumi Mobile Localization",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "unity": "2021.3",
   "description": "Localization controller, settings, and editor utilities for Bumi Mobile projects.",
   "keywords": [


### PR DESCRIPTION
## Summary
- Update the LocalizationSettings Create Asset menu path from Data/Simple Localization/Settings to BumiMobile/Localization Settings.
- Bump com.bumimobile.localization package version from 0.1.3 to 0.1.4.
- Add the 0.1.4 changelog entry documenting the menu path change.

## Validation
- Checked diff against origin/dev.
- Confirmed Data/Simple Localization no longer appears in com.bumimobile.localization C# files.