### PR TITLE
feat(save): multi-slot save file support via saveSlotIndex

### DIFF
--- a/Packages/com.bumimobile.save/CHANGELOG.md
+++ b/Packages/com.bumimobile.save/CHANGELOG.md
@@ -6,7 +6,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
-- (Add unreleased changes here)
+## [0.1.4] - 2026-06-29
+
+### Added
+
+- Added `saveSlotIndex` field to `SaveInitModule` and `SaveController` to support multiple save slots. When set to `1` or higher, the save file is named `save_1`, `save_2`, etc., allowing separate save files per reset or per device.
 
 ## [0.1.3] - 2026-04-29
 

--- a/Packages/com.bumimobile.save/Runtime/SaveController.cs
+++ b/Packages/com.bumimobile.save/Runtime/SaveController.cs
@@ -15,7 +15,7 @@ namespace BumiMobile
             OnSaveLoaded?.Invoke();         // backward-compat (dipanggil saat Local & Cloud)
             OnSavePhase?.Invoke(phase);     // fase spesifik
         }
-        private const string SAVE_FILE_NAME = "save";
+        private static string saveFileName = "save";
 
         private static GlobalSave globalSave;
         public static GlobalSave GlobalSave { get => globalSave; set => globalSave = value; }
@@ -31,8 +31,9 @@ namespace BumiMobile
 
         public static event SimpleCallback OnSaveLoaded;
 
-        public static void Init(float autoSaveDelay, GlobalSave initialGlobalSave, bool clearSave = false, float overrideTime = -1f)
+        public static void Init(float autoSaveDelay, GlobalSave initialGlobalSave, bool clearSave = false, float overrideTime = -1f, int saveSlotIndex = 0)
         {
+            saveFileName = saveSlotIndex > 0 ? $"save_{saveSlotIndex}" : "save";
             GlobalSave = initialGlobalSave ?? new GlobalSave();
             Serializer.Init();
 
@@ -96,7 +97,7 @@ namespace BumiMobile
                 return;
 
             // Try to read and deserialize file or create new one
-            globalSave = BaseSaveWrapper.ActiveWrapper.Load(SAVE_FILE_NAME);
+            globalSave = BaseSaveWrapper.ActiveWrapper.Load(saveFileName);
 
             globalSave.Init(time);
 
@@ -117,12 +118,12 @@ namespace BumiMobile
             BaseSaveWrapper saveWrapper = BaseSaveWrapper.ActiveWrapper;
             if (useThreads && saveWrapper.UseThreads())
             {
-                Thread saveThread = new Thread(() => BaseSaveWrapper.ActiveWrapper.Save(globalSave, SAVE_FILE_NAME));
+                Thread saveThread = new Thread(() => BaseSaveWrapper.ActiveWrapper.Save(globalSave, saveFileName));
                 saveThread.Start();
             }
             else
             {
-                BaseSaveWrapper.ActiveWrapper.Save(globalSave, SAVE_FILE_NAME);
+                BaseSaveWrapper.ActiveWrapper.Save(globalSave, saveFileName);
             }
 
             Debug.Log("[Save Controller]: Game is saved!");
@@ -136,7 +137,7 @@ namespace BumiMobile
             {
                 globalSave.Flush(false);
 
-                BaseSaveWrapper.ActiveWrapper.Save(globalSave, SAVE_FILE_NAME);
+                BaseSaveWrapper.ActiveWrapper.Save(globalSave, saveFileName);
             }
         }
 
@@ -171,12 +172,12 @@ namespace BumiMobile
 
         public static void DeleteSaveFile()
         {
-            BaseSaveWrapper.ActiveWrapper.Delete(SAVE_FILE_NAME);
+            BaseSaveWrapper.ActiveWrapper.Delete(saveFileName);
         }
 
         public static GlobalSave GetGlobalSave()
         {
-            GlobalSave tempGlobalSave = BaseSaveWrapper.ActiveWrapper.Load(SAVE_FILE_NAME);
+            GlobalSave tempGlobalSave = BaseSaveWrapper.ActiveWrapper.Load(saveFileName);
 
             tempGlobalSave.Init(Time.time);
 

--- a/Packages/com.bumimobile.save/Runtime/SaveInitModule.cs
+++ b/Packages/com.bumimobile.save/Runtime/SaveInitModule.cs
@@ -14,17 +14,18 @@ namespace BumiMobile
         [SerializeField] bool cleanSaveStart = false;
         [SerializeField] bool devCloudSave = false;
         [SerializeField] float cloudTimeout = 6f;
+        [SerializeField] int saveSlotIndex = 0;
         public override bool IsAsync => true;
 
         public override void CreateComponent()
         {
             ApplyCloudSaveEnvironment();
-            SaveController.Init(autoSaveDelay, new GlobalSave(), clearSave);
+            SaveController.Init(autoSaveDelay, new GlobalSave(), clearSave, saveSlotIndex: saveSlotIndex);
         }
         public override IEnumerator InitializeCoroutine(Initializer initializer)
         {
             ApplyCloudSaveEnvironment();
-            SaveController.Init(autoSaveDelay, new GlobalSave(), clearSave);
+            SaveController.Init(autoSaveDelay, new GlobalSave(), clearSave, saveSlotIndex: saveSlotIndex);
 
             if (PlayerPrefs.GetInt(SKIP_CLOUD_KEY, 0) == 1)
             {

--- a/Packages/com.bumimobile.save/package.json
+++ b/Packages/com.bumimobile.save/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.bumimobile.save",
   "displayName": "Bumi Mobile Save",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "unity": "2021.3",
   "description": "Save system, serializers, and storage helpers for Bumi Mobile projects.",
   "keywords": [


### PR DESCRIPTION
## Summary

Adds a `saveSlotIndex` integer to the save system, enabling multiple save files per device. This allows save resets without overwriting previous save data.

## Problem

Previously, the save system used a single hardcoded filename (`save`) â€” making it impossible to create separate save files when resetting progress or switching accounts on the same device.

## Solution

**SaveController** â€” Made the save file name dynamic:
- Changed `private const string SAVE_FILE_NAME` â†’ `private static string saveFileName`
- Added `int saveSlotIndex = 0` parameter to `Init()`
- File naming: slot `0` â†’ `save`, slot `1` â†’ `save_1`, slot `2` â†’ `save_2`, etc.
- All 6 internal references (Load, Save x2, SaveCustom, Delete, GetGlobalSave) now use the dynamic name
- Backward compatible â€” default `0` preserves existing behavior

**SaveInitModule** â€” Exposed the feature at module level:
- Added `[SerializeField] int saveSlotIndex = 0` field
- Wired to both `SaveController.Init()` calls in `CreateComponent()` and `InitializeCoroutine()`

## Files Changed

| File | + | - |
|---|---|---|
| `SaveController.cs` | 9 | 8 |
| `SaveInitModule.cs` | 3 | 2 |
| `CHANGELOG.md` | 5 | 1 |
| `package.json` | 1 | 1 |

## Behavior

- **Default (`saveSlotIndex = 0`)**: Save file is `save` â€” identical to previous behavior
- **Slot 1+**: Save file is `save_1`, `save_2`, etc. â€” clean separation between save lifetimes
- Works with both local file saves and Firebase cloud saves (cloud references the same dynamic filename)

## Usage

Set `saveSlotIndex` in the `SaveInitModule` inspector, or modify it programmatically before module initialization (e.g., reading a PlayerPrefs key during a reset flow).

## Version

Bumped `com.bumimobile.save` from `0.1.3` â†’ `0.1.4`
